### PR TITLE
refactor!: make rockspec source optional

### DIFF
--- a/rocks-lib/src/build/luarocks.rs
+++ b/rocks-lib/src/build/luarocks.rs
@@ -1,3 +1,4 @@
+use crate::lua_rockspec::Remote;
 use crate::rockspec::LuaVersionCompatibility;
 use crate::rockspec::Rockspec;
 use std::{io, path::Path};
@@ -26,7 +27,7 @@ pub enum LuarocksBuildError {
     ExecLuaRocksError(#[from] ExecLuaRocksError),
 }
 
-pub(crate) async fn build<R: Rockspec>(
+pub(crate) async fn build<R: Rockspec<RType = Remote>>(
     rockspec: &R,
     output_paths: &RockLayout,
     lua: &LuaInstallation,
@@ -54,7 +55,7 @@ pub(crate) async fn build<R: Rockspec>(
     install(rockspec, &luarocks_tree.into_path(), output_paths, config)
 }
 
-fn install<R: Rockspec>(
+fn install<R: Rockspec<RType = Remote>>(
     rockspec: &R,
     luarocks_tree: &Path,
     output_paths: &RockLayout,

--- a/rocks-lib/src/build/mod.rs
+++ b/rocks-lib/src/build/mod.rs
@@ -1,3 +1,4 @@
+use crate::lua_rockspec::Remote;
 use crate::rockspec::LuaVersionCompatibility;
 use crate::{lua_rockspec::LuaVersionError, rockspec::Rockspec};
 use std::{io, path::Path, process::ExitStatus};
@@ -44,7 +45,7 @@ pub mod variables;
 /// over how a package should be built.
 #[derive(Builder)]
 #[builder(start_fn = new, finish_fn(name = _build, vis = ""))]
-pub struct Build<'a, R: Rockspec + HasIntegrity> {
+pub struct Build<'a, R: Rockspec<RType = Remote> + HasIntegrity> {
     #[builder(start_fn)]
     rockspec: &'a R,
     #[builder(start_fn)]
@@ -65,7 +66,7 @@ pub struct Build<'a, R: Rockspec + HasIntegrity> {
 }
 
 // Overwrite the `build()` function to use our own instead.
-impl<R: Rockspec + HasIntegrity, State> BuildBuilder<'_, R, State>
+impl<R: Rockspec<RType = Remote> + HasIntegrity, State> BuildBuilder<'_, R, State>
 where
     State: build_builder::State + build_builder::IsComplete,
 {
@@ -135,7 +136,7 @@ impl From<bool> for BuildBehaviour {
     }
 }
 
-async fn run_build<R: Rockspec>(
+async fn run_build<R: Rockspec<RType = Remote>>(
     rockspec: &R,
     output_paths: &RockLayout,
     lua: &LuaInstallation,
@@ -180,7 +181,7 @@ async fn run_build<R: Rockspec>(
     )
 }
 
-async fn install<R: Rockspec>(
+async fn install<R: Rockspec<RType = Remote>>(
     rockspec: &R,
     tree: &Tree,
     output_paths: &RockLayout,
@@ -233,7 +234,7 @@ async fn install<R: Rockspec>(
     Ok(())
 }
 
-async fn do_build<R: Rockspec + HasIntegrity>(
+async fn do_build<R: Rockspec<RType = Remote> + HasIntegrity>(
     build: Build<'_, R>,
 ) -> Result<LocalPackage, BuildError> {
     build.progress.map(|p| {

--- a/rocks-lib/src/lockfile/mod.rs
+++ b/rocks-lib/src/lockfile/mod.rs
@@ -478,7 +478,7 @@ pub struct Lockfile<P: LockfilePermissions> {
 
 #[derive(Error, Debug)]
 pub enum LockfileIntegrityError {
-    #[error("rockspec integirty mismatch.\nExpected: {expected}\nBut got: {got}")]
+    #[error("rockspec integrity mismatch.\nExpected: {expected}\nBut got: {got}")]
     RockspecIntegrityMismatch { expected: Integrity, got: Integrity },
     #[error("source integrity mismatch.\nExpected: {expected}\nBut got: {got}")]
     SourceIntegrityMismatch { expected: Integrity, got: Integrity },

--- a/rocks-lib/src/luarocks/luarocks_installation.rs
+++ b/rocks-lib/src/luarocks/luarocks_installation.rs
@@ -15,7 +15,7 @@ use crate::{
     config::{Config, LuaVersion, LuaVersionUnset},
     lockfile::{LocalPackage, LocalPackageId, PinnedState},
     lua_installation::LuaInstallation,
-    lua_rockspec::{LuaRockspec, RockspecFormat},
+    lua_rockspec::{LuaRockspec, Remote, RockspecFormat},
     operations::{get_all_dependencies, SearchAndDownloadError},
     package::PackageReq,
     path::Paths,
@@ -117,7 +117,7 @@ impl LuaRocksInstallation {
         Ok(())
     }
 
-    pub async fn install_build_dependencies<R: Rockspec>(
+    pub async fn install_build_dependencies<R: Rockspec<RType = Remote>>(
         &self,
         build_backend: &str,
         rocks: &R,

--- a/rocks-lib/src/operations/fetch.rs
+++ b/rocks-lib/src/operations/fetch.rs
@@ -16,6 +16,7 @@ use thiserror::Error;
 
 use crate::config::Config;
 use crate::hash::HasIntegrity;
+use crate::lua_rockspec::Remote;
 use crate::lua_rockspec::RockSourceSpec;
 use crate::operations;
 use crate::package::PackageSpec;
@@ -29,7 +30,7 @@ use super::DownloadSrcRockError;
 /// over how a package should be fetched.
 #[derive(Builder)]
 #[builder(start_fn = new, finish_fn(name = _build, vis = ""))]
-pub struct FetchSrc<'a, R: Rockspec> {
+pub struct FetchSrc<'a, R: Rockspec<RType = Remote>> {
     #[builder(start_fn)]
     dest_dir: &'a Path,
     #[builder(start_fn)]
@@ -40,7 +41,7 @@ pub struct FetchSrc<'a, R: Rockspec> {
     progress: &'a Progress<ProgressBar>,
 }
 
-impl<R: Rockspec, State> FetchSrcBuilder<'_, R, State>
+impl<R: Rockspec<RType = Remote>, State> FetchSrcBuilder<'_, R, State>
 where
     State: fetch_src_builder::State + fetch_src_builder::IsComplete,
 {
@@ -120,7 +121,9 @@ pub enum FetchSrcRockError {
     Io(#[from] io::Error),
 }
 
-async fn do_fetch_src<R: Rockspec>(fetch: &FetchSrc<'_, R>) -> Result<Integrity, FetchSrcError> {
+async fn do_fetch_src<R: Rockspec<RType = Remote>>(
+    fetch: &FetchSrc<'_, R>,
+) -> Result<Integrity, FetchSrcError> {
     let rockspec = fetch.rockspec;
     let rock_source = rockspec.source().current_platform();
     let progress = fetch.progress;

--- a/rocks-lib/src/operations/test.rs
+++ b/rocks-lib/src/operations/test.rs
@@ -3,6 +3,7 @@ use std::{io, process::Command, sync::Arc};
 use crate::{
     build::BuildBehaviour,
     config::Config,
+    lua_rockspec::RockspecType,
     package::{PackageName, PackageReq, PackageVersionReqError},
     path::Paths,
     progress::{MultiProgress, Progress},
@@ -162,8 +163,8 @@ pub async fn ensure_busted(
 
 /// Ensure dependencies and test dependencies are installed
 /// This defaults to the local project tree if cwd is a project root.
-async fn ensure_dependencies(
-    rockspec: &impl Rockspec,
+async fn ensure_dependencies<T: RockspecType>(
+    rockspec: &impl Rockspec<RType = T>,
     tree: &Tree,
     config: &Config,
     progress: Arc<Progress<MultiProgress>>,


### PR DESCRIPTION
This is part of a larger initiative to allow `rocks test` and `rocks run` execute the current project without the need for a URL.