### PR TITLE
feat: use lockfile source when fetching a package

### DIFF
--- a/lux-lib/src/lockfile/mod.rs
+++ b/lux-lib/src/lockfile/mod.rs
@@ -225,7 +225,7 @@ pub(crate) enum RemotePackageSourceUrl {
 pub struct LocalPackage {
     pub(crate) spec: LocalPackageSpec,
     pub(crate) source: RemotePackageSource,
-    source_url: Option<RemotePackageSourceUrl>,
+    pub(crate) source_url: Option<RemotePackageSourceUrl>,
     hashes: LocalPackageHashes,
 }
 

--- a/lux-lib/src/manifest/mod.rs
+++ b/lux-lib/src/manifest/mod.rs
@@ -273,7 +273,7 @@ impl Manifest {
                         RemotePackageSource::LuarocksBinaryRock(self.server_url().clone())
                     }
                 };
-                Some(RemotePackage::new(package, remote_source))
+                Some(RemotePackage::new(package, remote_source, None))
             }
         }
     }

--- a/lux-lib/src/operations/install.rs
+++ b/lux-lib/src/operations/install.rs
@@ -330,6 +330,7 @@ async fn install_rockspec(
         .constraint(constraint)
         .behaviour(behaviour)
         .source(source)
+        .source_url(rockspec_download.source_url)
         .build()
         .await
         .map_err(|err| InstallError::BuildError(package, err))?;

--- a/lux-lib/src/package/mod.rs
+++ b/lux-lib/src/package/mod.rs
@@ -13,6 +13,7 @@ pub use version::{
 };
 
 use crate::{
+    lockfile::RemotePackageSourceUrl,
     lua_rockspec::{DisplayAsLuaKV, DisplayLuaKV, DisplayLuaValue},
     remote_package_source::RemotePackageSource,
 };
@@ -67,11 +68,21 @@ impl mlua::UserData for PackageSpec {
 pub(crate) struct RemotePackage {
     pub package: PackageSpec,
     pub source: RemotePackageSource,
+    /// `Some` if present in a lockfile
+    pub source_url: Option<RemotePackageSourceUrl>,
 }
 
 impl RemotePackage {
-    pub fn new(package: PackageSpec, source: RemotePackageSource) -> Self {
-        Self { package, source }
+    pub fn new(
+        package: PackageSpec,
+        source: RemotePackageSource,
+        source_url: Option<RemotePackageSourceUrl>,
+    ) -> Self {
+        Self {
+            package,
+            source,
+            source_url,
+        }
     }
 }
 

--- a/lux-lib/src/remote_package_db/mod.rs
+++ b/lux-lib/src/remote_package_db/mod.rs
@@ -84,6 +84,7 @@ impl RemotePackageDB {
                     RemotePackage::new(
                         PackageSpec::new(local_package.spec.name, local_package.spec.version),
                         local_package.source,
+                        local_package.source_url,
                     )
                 }) {
                     Some(package) => Ok(package),


### PR DESCRIPTION
Stacked on #422.

Closes #424.

With this PR, we use the lockfile's `source_url` as a source of truth for downloading the rock source.
That way, we're less likely to run into source integrity mismatches if no git revision or tag is specified in the rockspec source.