### PR TITLE
feat(update): operate on lux.toml and lux.lock if in a project

### DIFF
--- a/lux-cli/src/bin/lx.rs
+++ b/lux-cli/src/bin/lx.rs
@@ -71,7 +71,7 @@ async fn main() {
         Commands::Remove(remove_args) => remove::remove(remove_args, config).await.unwrap(),
         Commands::Run(run_args) => run::run(run_args, config).await.unwrap(),
         Commands::Test(test) => test::test(test, config).await.unwrap(),
-        Commands::Update(_update_args) => update::update(config).await.unwrap(),
+        Commands::Update(update_args) => update::update(update_args, config).await.unwrap(),
         Commands::Info(info_data) => info::info(info_data, config).await.unwrap(),
         Commands::Path(path_data) => path::path(path_data, config).await.unwrap(),
         Commands::Pin(pin_data) => pin::set_pinned_state(pin_data, config, Pinned).unwrap(),

--- a/lux-cli/src/sync.rs
+++ b/lux-cli/src/sync.rs
@@ -2,11 +2,12 @@ use std::path::PathBuf;
 
 use clap::Args;
 use eyre::{eyre, Context, Result};
+use itertools::Itertools;
 use lux_lib::{
     config::{Config, LuaVersion},
     lockfile::ProjectLockfile,
     operations,
-    package::PackageReq,
+    package::{PackageName, PackageReq},
     project::{project_toml::ProjectToml, PROJECT_TOML},
     rockspec::Rockspec,
 };
@@ -67,7 +68,10 @@ pub async fn sync(args: Sync, config: Config) -> Result<()> {
                 .into_validated()?
                 .dependencies()
                 .current_platform()
-                .clone())
+                .iter()
+                .filter(|package| !package.name().eq(&PackageName::new("lua".into())))
+                .cloned()
+                .collect_vec())
         })
         .transpose()?
     {

--- a/lux-lib/src/operations/test.rs
+++ b/lux-lib/src/operations/test.rs
@@ -104,13 +104,7 @@ async fn run_tests(test: Test<'_>) -> Result<(), RunTestsError> {
     } else {
         let mut lockfile = test.project.lockfile()?.write_guard();
 
-        let test_dependencies = rocks
-            .test_dependencies()
-            .current_platform()
-            .iter()
-            .filter(|req| !req.name().eq(&PackageName::new("lua".into())))
-            .cloned()
-            .collect_vec();
+        let test_dependencies = rocks.test_dependencies().current_platform().clone();
 
         Sync::new(&test_tree, &mut lockfile, test.config)
             .progress(test.progress.clone())


### PR DESCRIPTION
Stacked on #425.

Addresses #426 (partially).

Also fixes `Sync` so that it keeps only packages that have the same constraints as the `Vec<PackageReq>` constraints we pass in from the lux.toml dependencies.
This ensures that if we update a version constraint in `lux.toml`, it is reflected in the lockfile.