### PR TITLE
feat(lockfile): don't serialise dependencies fields if empty

### DIFF
--- a/lux-lib/resources/test/lux.lock
+++ b/lux-lib/resources/test/lux.lock
@@ -265,13 +265,5 @@
       "e7c4c9fcd3cb6fe33c1c0a2ab8cdbbe8ee81d11334277d1f5631c80317770769",
       "f98575efb520794ce8828bf0f5088047e745c27cd102cde14d4f6ad933efa00d"
     ]
-  },
-  "test_dependencies": {
-    "rocks": {},
-    "entrypoints": []
-  },
-  "build_dependencies": {
-    "rocks": {},
-    "entrypoints": []
   }
 }

--- a/lux-lib/src/lockfile/mod.rs
+++ b/lux-lib/src/lockfile/mod.rs
@@ -496,6 +496,10 @@ impl LocalPackageLock {
         self.rocks.get(id)
     }
 
+    fn is_empty(&self) -> bool {
+        self.entrypoints.is_empty()
+    }
+
     pub(crate) fn rocks(&self) -> &BTreeMap<LocalPackageId, LocalPackage> {
         &self.rocks
     }
@@ -631,11 +635,11 @@ pub struct ProjectLockfile<P: LockfilePermissions> {
     #[serde(skip)]
     _marker: PhantomData<P>,
     version: String,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "LocalPackageLock::is_empty")]
     dependencies: LocalPackageLock,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "LocalPackageLock::is_empty")]
     test_dependencies: LocalPackageLock,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "LocalPackageLock::is_empty")]
     build_dependencies: LocalPackageLock,
 }
 


### PR DESCRIPTION
This will make the lockfile a bit nicer when used with rocks.nvim, where we don't care about build/test dependencies.