### PR TITLE
build: use crane for clippy and rustfmt checks

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [alias]
 tt = "nextest run --tests --no-fail-fast" # All
-tl = "nextest run --lib --no-fail-fast" # Lib only
+tl = "nextest run --lib --no-fail-fast"   # Lib only
 xtask = "run --package xtask --"
 lx = "run --bin lx --"

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -25,9 +25,12 @@ jobs:
       with:
         name: neorocks
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-    - name: Checks
+    - name: Formatting
       run: nix build ".#checks.${{matrix.job.target}}.git-hooks-check" --accept-flake-config --log-lines 500
       if: ${{ matrix.job.target == 'x86_64-linux' }}
+      shell: bash
+    - name: Clippy
+      run: nix build ".#checks.${{matrix.job.target}}.clippy" --accept-flake-config --log-lines 500
       shell: bash
     - name: Tests
       run: nix build ".#checks.${{matrix.job.target}}.tests" --accept-flake-config --log-lines 500

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [workspace]
 members = [
-    "lux-lib",
-    "lux-cli",
-    "xtask",
-    # "lux-lua",
+  "lux-lib",
+  "lux-cli",
+  "xtask",
+  # "lux-lua",
 ]
 resolver = "2"

--- a/flake.nix
+++ b/flake.nix
@@ -38,18 +38,7 @@
             # to update CONTRIBUTING.md for non-nix users.
             alejandra.enable = true;
             rustfmt.enable = true;
-            clippy = {
-              enable = true;
-              settings = {
-                denyWarnings = true;
-                allFeatures = true;
-              };
-              extraPackages = pkgs.lux-cli.buildInputs ++ pkgs.lux-cli.nativeBuildInputs;
-            };
-            cargo-check.enable = true;
-          };
-          settings.rust.check.cargoDeps = pkgs.rustPlatform.importCargoLock {
-            lockFile = "${self}/Cargo.lock";
+            taplo.enable = true;
           };
         };
       in {
@@ -68,6 +57,7 @@
                   rust-analyzer
                   ra-multiplex
                   cargo-nextest
+                  clippy
                   lua_pkg
                   # Needed for integration test builds
                   pkg-config
@@ -76,8 +66,8 @@
                   zlib
                 ])
                 ++ self.checks.${system}.git-hooks-check.enabledPackages
-                ++ pkgs.lux.buildInputs
-                ++ pkgs.lux.nativeBuildInputs;
+                ++ pkgs.lux-cli.buildInputs
+                ++ pkgs.lux-cli.nativeBuildInputs;
             };
         in rec {
           default = lua51;
@@ -94,6 +84,7 @@
             git-hooks-check
             ;
           tests = pkgs.lux-nextest;
+          clippy = pkgs.lux-clippy;
         };
       };
       flake = {

--- a/lux-lib/Cargo.toml
+++ b/lux-lib/Cargo.toml
@@ -9,10 +9,7 @@ license = "MIT"
 readme = "../README.md"
 keywords = ["lua", "luarocks", "neovim", "packagemanager", "build"]
 categories = ["development-tools"]
-exclude = [
-    "tests/**",
-    "resources/test/**",
-]
+exclude = ["tests/**", "resources/test/**"]
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -26,7 +23,12 @@ git2 = "0.20.0"
 html-escape = "0.2.13"
 httpdate = "1.0.3"
 itertools = "0.14.0"
-mlua = { version = "0.10.1", features = ["luajit52", "serialize", "macros", "error-send"] }
+mlua = { version = "0.10.1", features = [
+  "luajit52",
+  "serialize",
+  "macros",
+  "error-send",
+] }
 pathdiff = "0.2.1"
 reqwest = { version = "0.12.0", features = ["json", "multipart"] }
 semver = "1.0.22"
@@ -50,7 +52,7 @@ openssl = "0.10.70"
 lua-src = "547.0.0"
 luajit-src = "210.5.10"
 target-lexicon = "0.13.0"
-clap = { version = "4.5.3", features = ["derive"], optional = true}
+clap = { version = "4.5.3", features = ["derive"], optional = true }
 infer = "0.19.0"
 indicatif = "0.17.8"
 sha2 = "0.10.8"

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -98,4 +98,10 @@ in {
       cargoNextestExtraArgs = "--no-fail-fast --lib"; # Disable integration tests
       cargoNextestPartitionsExtraArgs = "--no-tests=pass";
     });
+
+  lux-clippy = craneLib.cargoClippy (commonArgs
+    // {
+      src = self;
+      cargoArtifacts = lux-deps;
+    });
 }


### PR DESCRIPTION
- Use crane instead of git-hooks.nix for clippy checks, so we can reuse the cached dependencies.
- Add taplo to the git-hooks checks (for toml formatting).

Closes #447