### PR TITLE
feat(build): treesitter-parser build backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,9 +112,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.93"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+checksum = "6b964d184e89d9b6b67dd2715bc8e74cf3107fb2b529990c90cf517326150bf4"
 
 [[package]]
 name = "arbitrary"
@@ -367,9 +367,9 @@ checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
 
 [[package]]
 name = "cc"
-version = "1.2.1"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "jobserver",
  "libc",
@@ -983,6 +983,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1057,6 +1068,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs4"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c29c30684418547d476f0b48e84f4821639119c483b1eccd566c8cd0cd05f521"
+dependencies = [
+ "rustix",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1238,8 +1259,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1351,7 +1384,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.6.0",
+ "indexmap 2.7.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -1790,9 +1823,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.6.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.1",
@@ -1810,6 +1843,12 @@ dependencies = [
  "unicode-width 0.2.0",
  "web-time",
 ]
+
+[[package]]
+name = "indoc"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "infer"
@@ -2012,6 +2051,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2084,9 +2133,9 @@ checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "lua-src"
@@ -2197,10 +2246,14 @@ dependencies = [
  "tar",
  "target-lexicon 0.13.0",
  "tempdir",
- "thiserror 2.0.3",
+ "thiserror 2.0.11",
  "tokio",
  "toml",
  "toml_edit",
+ "tree-sitter",
+ "tree-sitter-config",
+ "tree-sitter-generate",
+ "tree-sitter-loader",
  "url",
  "vfs",
  "walkdir",
@@ -2301,7 +2354,7 @@ checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
 
@@ -2313,7 +2366,7 @@ checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi 0.3.9",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -2685,6 +2738,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "path-slash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2983,7 +3042,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -3039,9 +3098,9 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
- "thiserror 2.0.3",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -3148,7 +3207,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "spin",
  "untrusted",
@@ -3169,9 +3228,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
@@ -3337,15 +3396,18 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
 dependencies = [
  "serde_derive",
 ]
@@ -3392,9 +3454,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.215"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3403,11 +3465,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.132"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
+checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
 dependencies = [
- "indexmap 2.6.0",
+ "indexmap 2.7.1",
  "itoa",
  "memchr",
  "ryu",
@@ -3582,6 +3644,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallbitvec"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d31d263dd118560e1a492922182ab6ca6dc1d03a3bf54e7699993f31a4150e3f"
+
+[[package]]
 name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3682,6 +3750,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "strsim"
@@ -3939,12 +4013,13 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.14.0"
+version = "3.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
+checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "getrandom 0.3.1",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -3988,11 +4063,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.3"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
 dependencies = [
- "thiserror-impl 2.0.3",
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -4008,9 +4083,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.3"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4167,7 +4242,7 @@ version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap 2.6.0",
+ "indexmap 2.7.1",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -4252,6 +4327,111 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5168a515fe492af54c5cc8800ff8c840be09fa5168de45838afaecd3e008bce4"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-config"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cc936f362ccdeb8e23f7a980cd3080ac30dfcc8aef21f6022ecfd70b5efa47"
+dependencies = [
+ "anyhow",
+ "etcetera",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "tree-sitter-generate"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05beaa8023e08df928535c282cf684c4ca5151475348e73457161f76a50778e8"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap 2.7.1",
+ "indoc",
+ "log",
+ "regex",
+ "regex-syntax",
+ "rustc-hash",
+ "semver",
+ "serde",
+ "serde_json",
+ "smallbitvec",
+ "thiserror 2.0.11",
+ "tree-sitter",
+ "url",
+]
+
+[[package]]
+name = "tree-sitter-highlight"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457164f56e8dbbd0dc620c239bd7e2eb6025b76e4d1593a690bd4d9ed37bf168"
+dependencies = [
+ "regex",
+ "streaming-iterator",
+ "thiserror 2.0.11",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4013970217383f67b18aef68f6fb2e8d409bc5755227092d32efb0422ba24b8"
+
+[[package]]
+name = "tree-sitter-loader"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7af57cae21f4ade207ce91b0a6d1073f017f162723077251b590dc511783249"
+dependencies = [
+ "anyhow",
+ "cc",
+ "etcetera",
+ "fs4",
+ "indoc",
+ "libloading",
+ "once_cell",
+ "path-slash",
+ "regex",
+ "semver",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tree-sitter",
+ "tree-sitter-highlight",
+ "tree-sitter-tags",
+ "url",
+]
+
+[[package]]
+name = "tree-sitter-tags"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "309bb54b5ef16dbff7906fe9a3ef32cf51c836d68abf8e3a5794ab898e812209"
+dependencies = [
+ "memchr",
+ "regex",
+ "streaming-iterator",
+ "thiserror 2.0.11",
+ "tree-sitter",
 ]
 
 [[package]]
@@ -4438,6 +4618,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -4816,6 +5005,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags 2.6.0",
+]
+
+[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4978,7 +5176,7 @@ dependencies = [
  "displaydoc",
  "flate2",
  "hmac",
- "indexmap 2.6.0",
+ "indexmap 2.7.1",
  "lzma-rs",
  "memchr",
  "pbkdf2",

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The following table provides a brief (incomplete) comparison:
 | `command` build spec                                                  | :white_check_mark:           | :white_check_mark: |
 | custom build backends                                                 | :white_check_mark:[^1]       | :white_check_mark: |
 | `rust-mlua` build spec                                                | :white_check_mark: (builtin) | :white_check_mark: (external build backend) |
+| `treesitter-parser` build spec                                        | :white_check_mark: (builtin) | :white_check_mark: (external build backend) |
 | RockSpecs with CVS/Mercurial/SVN/SSCM sources                         | :x: (YAGNI[^2])              | :white_check_mark: |
 | install pre-built binary rocks                                        | :white_check_mark:           | :white_check_mark: |
 | parallel builds/installs                                              | :white_check_mark:           | :x:                |

--- a/lux-lib/Cargo.toml
+++ b/lux-lib/Cargo.toml
@@ -73,6 +73,10 @@ toml = "0.8.19"
 md5 = "0.7.0"
 toml_edit = "0.22.22"
 nix-nar = "0.3.0"
+tree-sitter-loader = "0.25.2"
+tree-sitter-generate = "0.25.1"
+tree-sitter = "0.25.2"
+tree-sitter-config = "0.25.2"
 
 [dev-dependencies]
 httptest = { version = "0.16.1" }

--- a/lux-lib/resources/test/tree-sitter-rust-0.0.43.rockspec
+++ b/lux-lib/resources/test/tree-sitter-rust-0.0.43.rockspec
@@ -1,0 +1,66 @@
+local git_ref = '6e883a2adea9414799300699e78c0d2f032b5c46'
+local modrev = '0.0.43'
+local specrev = '1'
+
+local repo_url = 'https://github.com/tree-sitter/tree-sitter-rust'
+
+rockspec_format = '3.0'
+package = 'tree-sitter-rust'
+version = modrev ..'-'.. specrev
+
+description = {
+  summary = 'tree-sitter parser for rust',
+  labels = { 'neovim', 'tree-sitter' } ,
+  homepage = 'https://github.com/tree-sitter/tree-sitter-rust',
+  license = 'UNKNOWN'
+}
+
+dependencies = { 'lua >= 5.1' }
+
+build_dependencies = {
+  'luarocks-build-treesitter-parser >= 5.0.0',
+}
+
+source = {
+  url = repo_url .. '/archive/' .. git_ref .. '.zip',
+  dir = 'tree-sitter-rust-' .. '6e883a2adea9414799300699e78c0d2f032b5c46',
+}
+
+build = {
+  type = "treesitter-parser",
+  lang = "rust",
+  parser = true,
+  generate = false,
+  generate_from_json = false,
+  location = nil,
+  copy_directories = { "queries" },
+  queries = {
+    ["folds.scm"] = [==[
+[
+  (mod_item)
+  (foreign_mod_item)
+  (function_item)
+  (struct_item)
+  (trait_item)
+  (enum_item)
+  (impl_item)
+  (type_item)
+  (union_item)
+  (const_item)
+  (let_declaration)
+  (loop_expression)
+  (for_expression)
+  (while_expression)
+  (if_expression)
+  (match_expression)
+  (call_expression)
+  (array_expression)
+  (macro_definition)
+  (macro_invocation)
+  (attribute_item)
+  (block)
+  (use_declaration)+
+] @fold
+]==],
+  },
+}

--- a/lux-lib/src/build/treesitter_parser.rs
+++ b/lux-lib/src/build/treesitter_parser.rs
@@ -1,0 +1,101 @@
+use crate::config::{Config, LuaVersionUnset};
+use crate::lua_installation::LuaInstallation;
+use crate::lua_rockspec::Build;
+use crate::lua_rockspec::{BuildInfo, TreesitterParserBuildSpec};
+use crate::progress::{Progress, ProgressBar};
+use crate::tree::RockLayout;
+use std::io;
+use std::num::ParseIntError;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+use tree_sitter_generate::GenerateError;
+
+const DEFAULT_GENERATE_ABI_VERSION: usize = tree_sitter::LANGUAGE_VERSION;
+
+#[derive(Error, Debug)]
+pub enum TreesitterBuildError {
+    #[error(transparent)]
+    LuaVersionUnset(#[from] LuaVersionUnset),
+    #[error("failed to initialise the tree-sitter loader: {0}")]
+    Loader(String),
+    #[error("invalid TREE_SITTER_LANGUAGE_VERSION: {0}")]
+    ParseAbiVersion(#[from] ParseIntError),
+    #[error("error generating tree-sitter grammar: {0}")]
+    Generate(#[from] GenerateError),
+    #[error("error compiling the tree-sitter grammar: {0}")]
+    TreesitterCompileError(String),
+    #[error("error creating directory {dir}: {err}")]
+    CreateDir { dir: PathBuf, err: io::Error },
+    #[error("error writing query file: {0}")]
+    WriteQuery(io::Error),
+}
+
+impl Build for TreesitterParserBuildSpec {
+    type Err = TreesitterBuildError;
+
+    async fn run(
+        self,
+        output_paths: &RockLayout,
+        _no_install: bool,
+        _lua: &LuaInstallation,
+        _config: &Config,
+        build_dir: &Path,
+        progress: &Progress<ProgressBar>,
+    ) -> Result<BuildInfo, Self::Err> {
+        let build_dir = self
+            .location
+            .map(|dir| build_dir.join(dir))
+            .unwrap_or(build_dir.to_path_buf());
+        if self.generate {
+            progress.map(|b| b.set_message("📖 ✍Generating tree-sitter grammar..."));
+            let abi_version = match std::env::var("TREE_SITTER_LANGUAGE_VERSION") {
+                Ok(v) => v.parse()?,
+                Err(_) => DEFAULT_GENERATE_ABI_VERSION,
+            };
+            tree_sitter_generate::generate_parser_in_directory(
+                &build_dir,
+                None,
+                None,
+                abi_version,
+                None,
+                None,
+            )?;
+        }
+        progress.map(|b| b.set_message("🌳 Building tree-sitter parser..."));
+        if self.parser {
+            let parser_dir = output_paths.etc.join("parser");
+            tokio::fs::create_dir_all(&parser_dir)
+                .await
+                .map_err(|err| TreesitterBuildError::CreateDir {
+                    dir: parser_dir.clone(),
+                    err,
+                })?;
+            let mut loader = tree_sitter_loader::Loader::new()
+                .map_err(|err| TreesitterBuildError::Loader(err.to_string()))?;
+            let output_path =
+                parser_dir.join(format!("{}.{}", self.lang, std::env::consts::DLL_EXTENSION));
+            loader.force_rebuild(true);
+            loader
+                .compile_parser_at_path(&build_dir, output_path, &[])
+                .map_err(|err| TreesitterBuildError::TreesitterCompileError(err.to_string()))?;
+        }
+
+        let queries_dir = output_paths.etc.join("queries");
+        if !self.queries.is_empty() {
+            tokio::fs::create_dir_all(&queries_dir)
+                .await
+                .map_err(|err| TreesitterBuildError::CreateDir {
+                    dir: queries_dir.clone(),
+                    err,
+                })?;
+        }
+        for (path, content) in self.queries {
+            let dest = queries_dir.join(path);
+            tokio::fs::write(&dest, content)
+                .await
+                .map_err(TreesitterBuildError::WriteQuery)?;
+        }
+
+        Ok(BuildInfo::default())
+    }
+}

--- a/lux-lib/src/lua_rockspec/build/tree_sitter.rs
+++ b/lux-lib/src/lua_rockspec/build/tree_sitter.rs
@@ -1,0 +1,20 @@
+use std::{collections::HashMap, path::PathBuf};
+
+#[derive(Debug, PartialEq, Default, Clone)]
+pub struct TreesitterParserBuildSpec {
+    /// Name of the parser language, e.g. "haskell"
+    pub(crate) lang: String,
+
+    /// Won't build the parser if `false`
+    /// (useful for packages that only include queries)
+    pub(crate) parser: bool,
+
+    /// Must the sources be generated?
+    pub(crate) generate: bool,
+
+    /// tree-sitter grammar's location (relative to the source root)
+    pub(crate) location: Option<PathBuf>,
+
+    /// Embedded queries to be installed in the `etc/queries` directory
+    pub(crate) queries: HashMap<PathBuf, String>,
+}

--- a/lux-lib/tests/build.rs
+++ b/lux-lib/tests/build.rs
@@ -102,3 +102,31 @@ async fn test_build_rockspec(rockspec_path: PathBuf) {
         .await
         .unwrap();
 }
+
+#[tokio::test]
+async fn treesitter_parser_build() {
+    let dir = TempDir::new("lux-test").unwrap();
+
+    let content = String::from_utf8(
+        std::fs::read("resources/test/tree-sitter-rust-0.0.43.rockspec").unwrap(),
+    )
+    .unwrap();
+    let rockspec = RemoteLuaRockspec::new(&content).unwrap();
+
+    let config = ConfigBuilder::new()
+        .unwrap()
+        .tree(Some(dir.into_path()))
+        .build()
+        .unwrap();
+
+    let progress = MultiProgress::new();
+    let bar = progress.new_bar();
+
+    let tree = config.tree(LuaVersion::from(&config).unwrap()).unwrap();
+
+    Build::new(&rockspec, &tree, &config, &Progress::Progress(bar))
+        .behaviour(Force)
+        .build()
+        .await
+        .unwrap();
+}


### PR DESCRIPTION
With this, `lux` users won't need to install tree-sitter-cli separately to build tree-sitter parsers.