### PR TITLE
refactor!: extract `LuaDependency` type

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+    "rust-analyzer.cargo.features": [
+      "luajit",
+      "clap",
+      "lua"
+    ],
+    "rust-analyzer.check.features": [
+      "luajit",
+      "clap",
+      "lua"
+    ]
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,9 +473,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.40"
+version = "4.5.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac2e663e3e3bed2d32d065a8404024dad306e699a04263ec59919529f803aee9"
+checksum = "f5c5508ea23c5366f77e53f5a0070e5a84e51687ec3ef9e0464c86dc8d13ce98"
 dependencies = [
  "clap 4.5.23",
 ]
@@ -522,9 +522,9 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "clap_mangen"
-version = "0.2.24"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbae9cbfdc5d4fa8711c09bd7b83f644cb48281ac35bf97af3e47b0675864bdf"
+checksum = "724842fa9b144f9b89b3f3d371a89f3455eea660361d13a554f68f8ae5d6c13a"
 dependencies = [
  "clap 4.5.23",
  "roff",

--- a/lux-cli/src/add.rs
+++ b/lux-cli/src/add.rs
@@ -8,6 +8,7 @@ use lux_lib::{
     progress::{MultiProgress, Progress, ProgressBar},
     project::Project,
     remote_package_db::RemotePackageDB,
+    rockspec::lua_dependency,
 };
 
 #[derive(clap::Args)]
@@ -58,7 +59,7 @@ pub async fn add(data: Add, config: Config) -> Result<()> {
 
         project
             .add(
-                lux_lib::project::DependencyType::Regular(data.package_req),
+                lua_dependency::DependencyType::Regular(data.package_req),
                 &db,
             )
             .await?;
@@ -79,7 +80,7 @@ pub async fn add(data: Add, config: Config) -> Result<()> {
         }
 
         project
-            .add(lux_lib::project::DependencyType::Build(build_packages), &db)
+            .add(lua_dependency::DependencyType::Build(build_packages), &db)
             .await?;
     }
 
@@ -96,7 +97,7 @@ pub async fn add(data: Add, config: Config) -> Result<()> {
                 .wrap_err("syncing test dependencies with the project lockfile failed.")?;
 
             project
-                .add(lux_lib::project::DependencyType::Test(test_packages), &db)
+                .add(lua_dependency::DependencyType::Test(test_packages), &db)
                 .await?;
         }
     }

--- a/lux-cli/src/install_rockspec.rs
+++ b/lux-cli/src/install_rockspec.rs
@@ -56,13 +56,13 @@ pub async fn install_rockspec(data: InstallRockspec, config: Config) -> Result<(
 
     let dependencies_to_install = dependencies
         .into_iter()
-        .filter(|req| {
-            tree.match_rocks(req)
+        .filter(|dep| {
+            tree.match_rocks(dep.package_req())
                 .is_ok_and(|rock_match| rock_match.is_found())
         })
         .map(|dep| {
             PackageInstallSpec::new(
-                dep.clone(),
+                dep.package_req().clone(),
                 BuildBehaviour::NoForce,
                 pin,
                 OptState::Required,

--- a/lux-cli/src/update.rs
+++ b/lux-cli/src/update.rs
@@ -5,6 +5,7 @@ use lux_lib::package::{PackageName, PackageReq};
 use lux_lib::progress::{MultiProgress, Progress, ProgressBar};
 use lux_lib::project::Project;
 use lux_lib::remote_package_db::RemotePackageDB;
+use lux_lib::rockspec::lua_dependency;
 use lux_lib::{config::Config, operations};
 
 #[derive(Args)]
@@ -47,21 +48,21 @@ pub async fn update(args: Update, config: Config) -> Result<()> {
         if let Some(packages) = package_names {
             upgrade_all = false;
             project
-                .upgrade(lux_lib::project::LuaDependencyType::Regular(packages), &db)
+                .upgrade(lua_dependency::LuaDependencyType::Regular(packages), &db)
                 .await?;
         }
         let build_package_names = to_package_names(args.build.as_ref())?;
         if let Some(packages) = build_package_names {
             upgrade_all = false;
             project
-                .upgrade(lux_lib::project::LuaDependencyType::Build(packages), &db)
+                .upgrade(lua_dependency::LuaDependencyType::Build(packages), &db)
                 .await?;
         }
         let test_package_names = to_package_names(args.test.as_ref())?;
         if let Some(packages) = test_package_names {
             upgrade_all = false;
             project
-                .upgrade(lux_lib::project::LuaDependencyType::Test(packages), &db)
+                .upgrade(lua_dependency::LuaDependencyType::Test(packages), &db)
                 .await?;
         }
         if upgrade_all {

--- a/lux-lib/src/lua_rockspec/mod.rs
+++ b/lux-lib/src/lua_rockspec/mod.rs
@@ -25,9 +25,9 @@ use url::Url;
 use crate::{
     config::{LuaVersion, LuaVersionUnset},
     hash::HasIntegrity,
-    package::{PackageName, PackageReq, PackageVersion},
+    package::{PackageName, PackageVersion},
     project::ProjectRoot,
-    rockspec::Rockspec,
+    rockspec::{lua_dependency::LuaDependencySpec, Rockspec},
 };
 
 #[derive(Error, Debug)]
@@ -51,10 +51,10 @@ pub struct LocalLuaRockspec {
     version: PackageVersion,
     description: RockDescription,
     supported_platforms: PlatformSupport,
-    dependencies: PerPlatform<Vec<PackageReq>>,
-    build_dependencies: PerPlatform<Vec<PackageReq>>,
+    dependencies: PerPlatform<Vec<LuaDependencySpec>>,
+    build_dependencies: PerPlatform<Vec<LuaDependencySpec>>,
     external_dependencies: PerPlatform<HashMap<String, ExternalDependencySpec>>,
-    test_dependencies: PerPlatform<Vec<PackageReq>>,
+    test_dependencies: PerPlatform<Vec<LuaDependencySpec>>,
     build: PerPlatform<BuildSpec>,
     source: PerPlatform<RemoteRockSource>,
     test: PerPlatform<TestSpec>,
@@ -167,11 +167,11 @@ impl Rockspec for LocalLuaRockspec {
         &self.supported_platforms
     }
 
-    fn dependencies(&self) -> &PerPlatform<Vec<PackageReq>> {
+    fn dependencies(&self) -> &PerPlatform<Vec<LuaDependencySpec>> {
         &self.dependencies
     }
 
-    fn build_dependencies(&self) -> &PerPlatform<Vec<PackageReq>> {
+    fn build_dependencies(&self) -> &PerPlatform<Vec<LuaDependencySpec>> {
         &self.build_dependencies
     }
 
@@ -179,7 +179,7 @@ impl Rockspec for LocalLuaRockspec {
         &self.external_dependencies
     }
 
-    fn test_dependencies(&self) -> &PerPlatform<Vec<PackageReq>> {
+    fn test_dependencies(&self) -> &PerPlatform<Vec<LuaDependencySpec>> {
         &self.test_dependencies
     }
 
@@ -298,11 +298,11 @@ impl Rockspec for RemoteLuaRockspec {
         self.local.supported_platforms()
     }
 
-    fn dependencies(&self) -> &PerPlatform<Vec<PackageReq>> {
+    fn dependencies(&self) -> &PerPlatform<Vec<LuaDependencySpec>> {
         self.local.dependencies()
     }
 
-    fn build_dependencies(&self) -> &PerPlatform<Vec<PackageReq>> {
+    fn build_dependencies(&self) -> &PerPlatform<Vec<LuaDependencySpec>> {
         self.local.build_dependencies()
     }
 
@@ -310,7 +310,7 @@ impl Rockspec for RemoteLuaRockspec {
         self.local.external_dependencies()
     }
 
-    fn test_dependencies(&self) -> &PerPlatform<Vec<PackageReq>> {
+    fn test_dependencies(&self) -> &PerPlatform<Vec<LuaDependencySpec>> {
         self.local.test_dependencies()
     }
 

--- a/lux-lib/src/lua_rockspec/partial.rs
+++ b/lux-lib/src/lua_rockspec/partial.rs
@@ -4,7 +4,8 @@ use mlua::{Lua, LuaSerdeExt, Value};
 
 use crate::{
     lua_rockspec::RockspecFormat,
-    package::{PackageName, PackageReq, PackageVersion},
+    package::{PackageName, PackageVersion},
+    rockspec::lua_dependency::LuaDependencySpec,
 };
 
 use super::{
@@ -19,10 +20,10 @@ pub struct PartialLuaRockspec {
     pub(crate) build: Option<BuildSpecInternal>,
     pub(crate) description: Option<RockDescription>,
     pub(crate) supported_platforms: Option<PlatformSupport>,
-    pub(crate) dependencies: Option<Vec<PackageReq>>,
-    pub(crate) build_dependencies: Option<Vec<PackageReq>>,
+    pub(crate) dependencies: Option<Vec<LuaDependencySpec>>,
+    pub(crate) build_dependencies: Option<Vec<LuaDependencySpec>>,
     pub(crate) external_dependencies: Option<HashMap<String, ExternalDependencySpec>>,
-    pub(crate) test_dependencies: Option<Vec<PackageReq>>,
+    pub(crate) test_dependencies: Option<Vec<LuaDependencySpec>>,
     pub(crate) source: Option<RockSourceInternal>,
     pub(crate) test: Option<TestSpecInternal>,
 }

--- a/lux-lib/src/luarocks/luarocks_installation.rs
+++ b/lux-lib/src/luarocks/luarocks_installation.rs
@@ -151,7 +151,7 @@ impl LuaRocksInstallation {
             _ => rocks.build_dependencies().current_platform().to_vec(),
         }
         .into_iter()
-        .map(|dep| PackageInstallSpec::default_for(dep))
+        .map(|dep| PackageInstallSpec::default_for(dep.package_req))
         .collect_vec();
 
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();

--- a/lux-lib/src/operations/install.rs
+++ b/lux-lib/src/operations/install.rs
@@ -293,6 +293,7 @@ async fn install_impl(
     Ok(installed_packages.into_values().collect_vec())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn install_rockspec(
     rockspec_download: DownloadedRockspec,
     constraint: LockConstraint,
@@ -335,6 +336,7 @@ async fn install_rockspec(
     Ok(pkg)
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn install_binary_rock(
     rockspec_download: DownloadedRockspec,
     packed_rock: Bytes,

--- a/lux-lib/src/operations/resolve.rs
+++ b/lux-lib/src/operations/resolve.rs
@@ -84,7 +84,7 @@ where
                             .iter()
                             .filter(|dep| !dep.name().eq(&"lua".into()))
                             .map(|dep| PackageInstallSpec {
-                                package: dep.clone(),
+                                package: dep.package_req().clone(),
                                 build_behaviour,
                                 pin,
                                 opt,

--- a/lux-lib/src/package/mod.rs
+++ b/lux-lib/src/package/mod.rs
@@ -16,6 +16,7 @@ use crate::{
     lockfile::RemotePackageSourceUrl,
     lua_rockspec::{DisplayAsLuaKV, DisplayLuaKV, DisplayLuaValue},
     remote_package_source::RemotePackageSource,
+    rockspec::lua_dependency::LuaDependencySpec,
 };
 
 #[derive(Clone, Debug)]
@@ -255,9 +256,9 @@ impl mlua::UserData for PackageReq {
 }
 
 /// Wrapper structs for proper serialization of various dependency types.
-pub(crate) struct Dependencies<'a>(pub(crate) &'a Vec<PackageReq>);
-pub(crate) struct BuildDependencies<'a>(pub(crate) &'a Vec<PackageReq>);
-pub(crate) struct TestDependencies<'a>(pub(crate) &'a Vec<PackageReq>);
+pub(crate) struct Dependencies<'a>(pub(crate) &'a Vec<LuaDependencySpec>);
+pub(crate) struct BuildDependencies<'a>(pub(crate) &'a Vec<LuaDependencySpec>);
+pub(crate) struct TestDependencies<'a>(pub(crate) &'a Vec<LuaDependencySpec>);
 
 impl DisplayAsLuaKV for Dependencies<'_> {
     fn display_lua(&self) -> DisplayLuaKV {

--- a/lux-lib/src/rockspec/lua_dependency.rs
+++ b/lux-lib/src/rockspec/lua_dependency.rs
@@ -1,0 +1,173 @@
+use std::{collections::HashMap, convert::Infallible, fmt::Display, str::FromStr};
+
+use mlua::{FromLua, LuaSerdeExt};
+use serde::{Deserialize, Deserializer};
+use thiserror::Error;
+
+use crate::{
+    lua_rockspec::{ExternalDependencySpec, PartialOverride, PerPlatform, PlatformOverridable},
+    package::{PackageName, PackageReq, PackageReqParseError, PackageSpec, PackageVersionReq},
+};
+
+#[derive(Error, Debug)]
+pub enum LuaDependencySpecParseError {
+    #[error(transparent)]
+    PackageReq(#[from] PackageReqParseError),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct LuaDependencySpec {
+    pub(crate) package_req: PackageReq,
+}
+
+impl LuaDependencySpec {
+    pub fn package_req(&self) -> &PackageReq {
+        &self.package_req
+    }
+    pub fn into_package_req(self) -> PackageReq {
+        self.package_req
+    }
+    pub fn name(&self) -> &PackageName {
+        self.package_req.name()
+    }
+    pub fn version_req(&self) -> &PackageVersionReq {
+        self.package_req.version_req()
+    }
+    pub fn matches(&self, package: &PackageSpec) -> bool {
+        self.package_req.matches(package)
+    }
+}
+
+impl From<PackageName> for LuaDependencySpec {
+    fn from(name: PackageName) -> Self {
+        Self {
+            package_req: PackageReq::from(name),
+        }
+    }
+}
+
+impl From<PackageReq> for LuaDependencySpec {
+    fn from(package_req: PackageReq) -> Self {
+        Self { package_req }
+    }
+}
+
+impl FromStr for LuaDependencySpec {
+    type Err = LuaDependencySpecParseError;
+
+    fn from_str(str: &str) -> Result<Self, LuaDependencySpecParseError> {
+        let package_req = PackageReq::from_str(str)?;
+        Ok(Self { package_req })
+    }
+}
+
+impl Display for LuaDependencySpec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.version_req().is_any() {
+            self.name().fmt(f)
+        } else {
+            f.write_str(format!("{} {}", self.name(), self.version_req()).as_str())
+        }
+    }
+}
+
+/// Override `base_deps` with `override_deps`
+/// - Adds missing dependencies
+/// - Replaces dependencies with the same name
+impl PartialOverride for Vec<LuaDependencySpec> {
+    type Err = Infallible;
+
+    fn apply_overrides(&self, override_vec: &Self) -> Result<Self, Self::Err> {
+        let mut result_map: HashMap<String, LuaDependencySpec> = self
+            .iter()
+            .map(|dep| (dep.name().clone().to_string(), dep.clone()))
+            .collect();
+        for override_dep in override_vec {
+            result_map.insert(
+                override_dep.name().clone().to_string(),
+                override_dep.clone(),
+            );
+        }
+        Ok(result_map.into_values().collect())
+    }
+}
+
+impl PlatformOverridable for Vec<LuaDependencySpec> {
+    type Err = Infallible;
+
+    fn on_nil<T>() -> Result<super::PerPlatform<T>, <Self as PlatformOverridable>::Err>
+    where
+        T: PlatformOverridable,
+        T: Default,
+    {
+        Ok(PerPlatform::default())
+    }
+}
+
+impl FromLua for LuaDependencySpec {
+    fn from_lua(value: mlua::Value, lua: &mlua::Lua) -> mlua::Result<Self> {
+        let package_req = lua.from_value(value)?;
+        Ok(Self { package_req })
+    }
+}
+
+impl<'de> Deserialize<'de> for LuaDependencySpec {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let package_req = PackageReq::deserialize(deserializer)?;
+        Ok(Self { package_req })
+    }
+}
+
+impl mlua::UserData for LuaDependencySpec {
+    fn add_methods<M: mlua::UserDataMethods<Self>>(methods: &mut M) {
+        methods.add_method("name", |_, this, ()| Ok(this.name().to_string()));
+        methods.add_method("version_req", |_, this, ()| {
+            Ok(this.version_req().to_string())
+        });
+        methods.add_method("matches", |_, this, package: PackageSpec| {
+            Ok(this.matches(&package))
+        });
+        methods.add_method("package_req", |_, this, ()| Ok(this.package_req().clone()));
+    }
+}
+
+pub enum DependencyType<T> {
+    Regular(Vec<T>),
+    Build(Vec<T>),
+    Test(Vec<T>),
+    External(HashMap<String, ExternalDependencySpec>),
+}
+
+pub enum LuaDependencyType<T> {
+    Regular(Vec<T>),
+    Build(Vec<T>),
+    Test(Vec<T>),
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_override_lua_dependency_spec() {
+        let neorg_a: LuaDependencySpec = "neorg 1.0.0".parse().unwrap();
+        let neorg_b: LuaDependencySpec = "neorg 2.0.0".parse().unwrap();
+        let foo: LuaDependencySpec = "foo 1.0.0".parse().unwrap();
+        let bar: LuaDependencySpec = "bar 1.0.0".parse().unwrap();
+        let base_vec = vec![neorg_a, foo.clone()];
+        let override_vec = vec![neorg_b.clone(), bar.clone()];
+        let result = base_vec.apply_overrides(&override_vec).unwrap();
+        assert_eq!(result.clone().len(), 3);
+        assert_eq!(
+            result
+                .into_iter()
+                .filter(|dep| *dep == neorg_b || *dep == foo || *dep == bar)
+                .count(),
+            3
+        );
+    }
+}

--- a/lux-lib/src/rockspec/mod.rs
+++ b/lux-lib/src/rockspec/mod.rs
@@ -5,8 +5,10 @@ use std::{
 };
 
 use itertools::Itertools;
+use lua_dependency::LuaDependencySpec;
 use mlua::IntoLua;
 use serde::{Deserialize, Serialize};
+pub mod lua_dependency;
 
 use crate::{
     config::{Config, LuaVersion},
@@ -14,7 +16,7 @@ use crate::{
         BuildSpec, ExternalDependencySpec, LuaVersionError, PerPlatform, PlatformSupport,
         RemoteRockSource, RockDescription, RockspecFormat, TestSpec,
     },
-    package::{PackageName, PackageReq, PackageVersion},
+    package::{PackageName, PackageVersion},
 };
 
 pub trait Rockspec {
@@ -22,10 +24,10 @@ pub trait Rockspec {
     fn version(&self) -> &PackageVersion;
     fn description(&self) -> &RockDescription;
     fn supported_platforms(&self) -> &PlatformSupport;
-    fn dependencies(&self) -> &PerPlatform<Vec<PackageReq>>;
-    fn build_dependencies(&self) -> &PerPlatform<Vec<PackageReq>>;
+    fn dependencies(&self) -> &PerPlatform<Vec<LuaDependencySpec>>;
+    fn build_dependencies(&self) -> &PerPlatform<Vec<LuaDependencySpec>>;
     fn external_dependencies(&self) -> &PerPlatform<HashMap<String, ExternalDependencySpec>>;
-    fn test_dependencies(&self) -> &PerPlatform<Vec<PackageReq>>;
+    fn test_dependencies(&self) -> &PerPlatform<Vec<LuaDependencySpec>>;
 
     fn build(&self) -> &PerPlatform<BuildSpec>;
     fn test(&self) -> &PerPlatform<TestSpec>;
@@ -116,7 +118,7 @@ impl<T: Rockspec> LuaVersionCompatibility for T {
 }
 
 pub(crate) fn latest_lua_version(
-    dependencies: &PerPlatform<Vec<PackageReq>>,
+    dependencies: &PerPlatform<Vec<LuaDependencySpec>>,
 ) -> Option<LuaVersion> {
     dependencies
         .current_platform()

--- a/lux-lua/Cargo.toml
+++ b/lux-lua/Cargo.toml
@@ -13,7 +13,9 @@ path-absolutize = "3.1.1"
 lux-workspace-hack = { version = "0.1", path = "../lux-workspace-hack" }
 
 [features]
+default = ["luajit"]
 lua51 = ["mlua/lua51", "lux-lib/lua51"]
 lua52 = ["mlua/lua52", "lux-lib/lua52"]
 lua53 = ["mlua/lua53", "lux-lib/lua53"]
 lua54 = ["mlua/lua54", "lux-lib/lua54"]
+luajit = ["mlua/luajit", "lux-lib/luajit"]

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -178,5 +178,6 @@ in {
       inherit (luxCliCargo) pname version;
       src = cleanCargoSrc;
       cargoArtifacts = lux-deps;
+      cargoClippyExtraArgs = "--all-targets -- --deny warnings";
     });
 }


### PR DESCRIPTION
Stacked on #453.

This doesn't change any behaviour yet. It's just in preparation for supporting things like

```toml
[dependencies.foo]
version = "1.0.0"
opt = true
pin = true
```

This PR introduces a `LuaDependency` type, which is equivalent to `PackageReq`, but will be able to hold more info in the future, which may be useful for building local projects.