### PR TITLE
feat!(toml): `opt` and `pin` fields

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,11 +2,13 @@
     "rust-analyzer.cargo.features": [
       "luajit",
       "clap",
-      "lua"
+      "lua",
+      "test"
     ],
     "rust-analyzer.check.features": [
       "luajit",
       "clap",
-      "lua"
+      "lua",
+      "test"
     ]
 }

--- a/lux-cli/src/check.rs
+++ b/lux-cli/src/check.rs
@@ -1,7 +1,8 @@
 use eyre::{OptionExt, Result};
 use lux_lib::{
     config::Config,
-    operations::{Install, PackageInstallSpec, Run},
+    operations::{Install, Run},
+    package::PackageReq,
     progress::MultiProgress,
     project::Project,
 };
@@ -9,8 +10,9 @@ use lux_lib::{
 pub async fn check(config: Config) -> Result<()> {
     let project = Project::current()?.ok_or_eyre("Not in a project!")?;
 
+    let luacheck: PackageReq = "luacheck".parse()?;
     Install::new(&project.tree(&config)?, &config)
-        .package(PackageInstallSpec::default_for("luacheck".parse()?))
+        .package(luacheck.into())
         .progress(MultiProgress::new_arc())
         .install()
         .await?;

--- a/lux-cli/src/remove.rs
+++ b/lux-cli/src/remove.rs
@@ -1,6 +1,5 @@
 use clap::Args;
 use eyre::{Context, OptionExt, Result};
-use itertools::Itertools;
 use lux_lib::{
     config::Config,
     luarocks::luarocks_installation::LuaRocksInstallation,
@@ -44,10 +43,7 @@ pub async fn remove(data: Remove, config: Config) -> Result<()> {
                 .into_local()?
                 .dependencies()
                 .current_platform()
-                .iter()
-                .cloned()
-                .map(|dep| dep.into_package_req())
-                .collect_vec();
+                .clone();
             Sync::new(&tree, &mut lockfile, &config)
                 .packages(packages)
                 .progress(progress.clone())
@@ -70,10 +66,7 @@ pub async fn remove(data: Remove, config: Config) -> Result<()> {
                 .into_local()?
                 .build_dependencies()
                 .current_platform()
-                .iter()
-                .cloned()
-                .map(|dep| dep.into_package_req())
-                .collect_vec();
+                .clone();
             Sync::new(luarocks.tree(), &mut lockfile, luarocks.config())
                 .packages(packages)
                 .progress(progress.clone())
@@ -95,10 +88,7 @@ pub async fn remove(data: Remove, config: Config) -> Result<()> {
                 .into_local()?
                 .test_dependencies()
                 .current_platform()
-                .iter()
-                .cloned()
-                .map(|dep| dep.into_package_req())
-                .collect_vec();
+                .clone();
             Sync::new(&tree, &mut lockfile, &config)
                 .packages(packages)
                 .progress(progress.clone())

--- a/lux-lib/src/luarocks/luarocks_installation.rs
+++ b/lux-lib/src/luarocks/luarocks_installation.rs
@@ -151,7 +151,7 @@ impl LuaRocksInstallation {
             _ => rocks.build_dependencies().current_platform().to_vec(),
         }
         .into_iter()
-        .map(|dep| PackageInstallSpec::default_for(dep.package_req))
+        .map(PackageInstallSpec::from)
         .collect_vec();
 
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();

--- a/lux-lib/src/operations/install_spec.rs
+++ b/lux-lib/src/operations/install_spec.rs
@@ -2,6 +2,7 @@ use crate::{
     build::BuildBehaviour,
     lockfile::{OptState, PinnedState},
     package::PackageReq,
+    rockspec::lua_dependency::LuaDependencySpec,
 };
 
 /// Specifies how to install a package
@@ -26,12 +27,26 @@ impl PackageInstallSpec {
             opt,
         }
     }
-    pub fn default_for(package: PackageReq) -> Self {
+}
+
+impl From<PackageReq> for PackageInstallSpec {
+    fn from(package: PackageReq) -> Self {
         Self {
             package,
             build_behaviour: BuildBehaviour::default(),
             pin: PinnedState::default(),
             opt: OptState::default(),
+        }
+    }
+}
+
+impl From<LuaDependencySpec> for PackageInstallSpec {
+    fn from(value: LuaDependencySpec) -> Self {
+        Self {
+            package: value.package_req,
+            build_behaviour: BuildBehaviour::default(),
+            pin: value.pin,
+            opt: value.opt,
         }
     }
 }

--- a/lux-lib/src/operations/run.rs
+++ b/lux-lib/src/operations/run.rs
@@ -13,7 +13,7 @@ use bon::Builder;
 use itertools::Itertools;
 use thiserror::Error;
 
-use super::{InstallError, PackageInstallSpec};
+use super::InstallError;
 
 /// Rocks package runner, providing fine-grained control
 /// over how a package should be run.
@@ -113,7 +113,7 @@ pub enum InstallCmdError {
 pub async fn install_command(command: &str, config: &Config) -> Result<(), InstallCmdError> {
     let package_req = PackageReq::new(command.into(), None)?;
     Install::new(&config.tree(LuaVersion::from(config)?)?, config)
-        .package(PackageInstallSpec::default_for(package_req))
+        .package(package_req.into())
         .install()
         .await?;
     Ok(())

--- a/lux-lib/src/project/mod.rs
+++ b/lux-lib/src/project/mod.rs
@@ -556,9 +556,9 @@ mod tests {
         let mut project = Project::from(&project_root).unwrap().unwrap();
         let add_dependencies =
             vec![PackageReq::new("busted".into(), Some(">= 1.0.0".into())).unwrap()];
-        let expected_dependencies = vec![LuaDependencySpec {
-            package_req: PackageReq::new("busted".into(), Some(">= 1.0.0".into())).unwrap(),
-        }];
+        let expected_dependencies = vec![PackageReq::new("busted".into(), Some(">= 1.0.0".into()))
+            .unwrap()
+            .into()];
 
         let test_manifest_path =
             PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("resources/test/manifest-5.1");


### PR DESCRIPTION
Stacked on #454.

This adds the ability to set the `opt` and `pin` fields for a Lua dependency via the `lux.toml` entries.