### PR TITLE
feat!: allow overriding `etc` tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2289,6 +2289,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
+ "getrandom 0.2.15",
  "hyper",
  "hyper-util",
  "indexmap 1.9.3",

--- a/lux-cli/src/bin/lx.rs
+++ b/lux-cli/src/bin/lx.rs
@@ -36,7 +36,7 @@ async fn main() {
         .verbose(Some(cli.verbose));
 
     if cli.nvim {
-        config_builder = config_builder.rock_layout(RockLayoutConfig::new_nvim_layout());
+        config_builder = config_builder.entrypoint_layout(RockLayoutConfig::new_nvim_layout());
     }
 
     let config = config_builder.build().unwrap();

--- a/lux-cli/src/bin/lx.rs
+++ b/lux-cli/src/bin/lx.rs
@@ -10,7 +10,7 @@ use lux_cli::{
     which, Cli, Commands,
 };
 use lux_lib::{
-    config::ConfigBuilder,
+    config::{tree::RockLayoutConfig, ConfigBuilder},
     lockfile::PinnedState::{Pinned, Unpinned},
 };
 
@@ -18,7 +18,7 @@ use lux_lib::{
 async fn main() {
     let cli = Cli::parse();
 
-    let config = ConfigBuilder::new()
+    let mut config_builder = ConfigBuilder::new()
         .unwrap()
         .dev(Some(cli.dev))
         .lua_dir(cli.lua_dir)
@@ -33,9 +33,13 @@ async fn main() {
                 .map(|duration| Duration::from_secs(duration as u64)),
         )
         .no_project(Some(cli.no_project))
-        .verbose(Some(cli.verbose))
-        .build()
-        .unwrap();
+        .verbose(Some(cli.verbose));
+
+    if cli.nvim {
+        config_builder = config_builder.rock_layout(RockLayoutConfig::new_nvim_layout());
+    }
+
+    let config = config_builder.build().unwrap();
 
     match cli.command {
         Commands::Search(search_data) => search::search(search_data, config).await.unwrap(),

--- a/lux-cli/src/build.rs
+++ b/lux-cli/src/build.rs
@@ -127,7 +127,7 @@ Use --ignore-lockfile to force a new build.
             )?;
     }
 
-    build::Build::new(&rocks, &tree, &config, &progress.map(|p| p.new_bar()))
+    build::Build::new(&rocks, &tree, true, &config, &progress.map(|p| p.new_bar()))
         .behaviour(BuildBehaviour::Force)
         .build()
         .await?;

--- a/lux-cli/src/build.rs
+++ b/lux-cli/src/build.rs
@@ -61,6 +61,7 @@ pub async fn build(data: Build, config: Config) -> Result<()> {
                     BuildBehaviour::default(),
                     *dep.pin(),
                     *dep.opt(),
+                    true,
                 )
             });
 
@@ -77,7 +78,15 @@ pub async fn build(data: Build, config: Config) -> Result<()> {
                 tree.match_rocks(dep.package_req())
                     .is_ok_and(|rock_match| !rock_match.is_found())
             })
-            .map(PackageInstallSpec::from)
+            .map(|dep| {
+                PackageInstallSpec::new(
+                    dep.clone().into_package_req(),
+                    BuildBehaviour::default(),
+                    *dep.pin(),
+                    *dep.opt(),
+                    true,
+                )
+            })
             .collect_vec();
 
         if !build_dependencies_to_install.is_empty() {

--- a/lux-cli/src/build.rs
+++ b/lux-cli/src/build.rs
@@ -13,6 +13,7 @@ use lux_lib::{
     progress::MultiProgress,
     project::Project,
     rockspec::Rockspec,
+    tree,
 };
 
 #[derive(Args, Default)]
@@ -61,7 +62,7 @@ pub async fn build(data: Build, config: Config) -> Result<()> {
                     BuildBehaviour::default(),
                     *dep.pin(),
                     *dep.opt(),
-                    true,
+                    tree::EntryType::Entrypoint,
                 )
             });
 
@@ -84,7 +85,7 @@ pub async fn build(data: Build, config: Config) -> Result<()> {
                     BuildBehaviour::default(),
                     *dep.pin(),
                     *dep.opt(),
-                    true,
+                    tree::EntryType::Entrypoint,
                 )
             })
             .collect_vec();
@@ -127,10 +128,16 @@ Use --ignore-lockfile to force a new build.
             )?;
     }
 
-    build::Build::new(&rocks, &tree, true, &config, &progress.map(|p| p.new_bar()))
-        .behaviour(BuildBehaviour::Force)
-        .build()
-        .await?;
+    build::Build::new(
+        &rocks,
+        &tree,
+        tree::EntryType::Entrypoint,
+        &config,
+        &progress.map(|p| p.new_bar()),
+    )
+    .behaviour(BuildBehaviour::Force)
+    .build()
+    .await?;
 
     Ok(())
 }

--- a/lux-cli/src/check.rs
+++ b/lux-cli/src/check.rs
@@ -6,6 +6,7 @@ use lux_lib::{
     operations::{Install, PackageInstallSpec, Run},
     progress::MultiProgress,
     project::Project,
+    tree,
 };
 
 pub async fn check(config: Config) -> Result<()> {
@@ -16,7 +17,7 @@ pub async fn check(config: Config) -> Result<()> {
         BuildBehaviour::default(),
         PinnedState::default(),
         OptState::default(),
-        true,
+        tree::EntryType::Entrypoint,
     );
 
     Install::new(&project.tree(&config)?, &config)

--- a/lux-cli/src/check.rs
+++ b/lux-cli/src/check.rs
@@ -1,8 +1,9 @@
 use eyre::{OptionExt, Result};
 use lux_lib::{
+    build::BuildBehaviour,
     config::Config,
-    operations::{Install, Run},
-    package::PackageReq,
+    lockfile::{OptState, PinnedState},
+    operations::{Install, PackageInstallSpec, Run},
     progress::MultiProgress,
     project::Project,
 };
@@ -10,9 +11,16 @@ use lux_lib::{
 pub async fn check(config: Config) -> Result<()> {
     let project = Project::current()?.ok_or_eyre("Not in a project!")?;
 
-    let luacheck: PackageReq = "luacheck".parse()?;
+    let luacheck = PackageInstallSpec::new(
+        "luacheck".parse()?,
+        BuildBehaviour::default(),
+        PinnedState::default(),
+        OptState::default(),
+        true,
+    );
+
     Install::new(&project.tree(&config)?, &config)
-        .package(luacheck.into())
+        .package(luacheck)
         .progress(MultiProgress::new_arc())
         .install()
         .await?;

--- a/lux-cli/src/doc.rs
+++ b/lux-cli/src/doc.rs
@@ -62,14 +62,14 @@ async fn open_homepage(pkg: LocalPackage, tree: &Tree) -> Result<()> {
 }
 
 fn get_homepage(pkg: &LocalPackage, tree: &Tree) -> Result<Option<Url>> {
-    let layout = tree.rock_layout(pkg);
+    let layout = tree.rock_layout(pkg)?;
     let rockspec_content = std::fs::read_to_string(layout.rockspec_path())?;
     let rockspec = RemoteLuaRockspec::new(&rockspec_content)?;
     Ok(rockspec.description().homepage.clone())
 }
 
 async fn open_local_docs(pkg: LocalPackage, tree: &Tree) -> Result<()> {
-    let layout = tree.rock_layout(&pkg);
+    let layout = tree.rock_layout(&pkg)?;
     let files: Vec<String> = WalkDir::new(&layout.doc)
         .into_iter()
         .filter_map_ok(|file| {

--- a/lux-cli/src/doc.rs
+++ b/lux-cli/src/doc.rs
@@ -62,14 +62,14 @@ async fn open_homepage(pkg: LocalPackage, tree: &Tree) -> Result<()> {
 }
 
 fn get_homepage(pkg: &LocalPackage, tree: &Tree) -> Result<Option<Url>> {
-    let layout = tree.rock_layout(pkg)?;
+    let layout = tree.installed_rock_layout(pkg)?;
     let rockspec_content = std::fs::read_to_string(layout.rockspec_path())?;
     let rockspec = RemoteLuaRockspec::new(&rockspec_content)?;
     Ok(rockspec.description().homepage.clone())
 }
 
 async fn open_local_docs(pkg: LocalPackage, tree: &Tree) -> Result<()> {
-    let layout = tree.rock_layout(&pkg)?;
+    let layout = tree.installed_rock_layout(&pkg)?;
     let files: Vec<String> = WalkDir::new(&layout.doc)
         .into_iter()
         .filter_map_ok(|file| {

--- a/lux-cli/src/install.rs
+++ b/lux-cli/src/install.rs
@@ -29,7 +29,7 @@ pub async fn install(data: Install, config: Config) -> Result<()> {
     let lua_version = LuaVersion::from(&config)?;
     let tree = config.tree(lua_version)?;
 
-    let packages = apply_build_behaviour(data.package_req, pin, data.force, &tree);
+    let packages = apply_build_behaviour(data.package_req, pin, data.force, &tree)?;
 
     // TODO(vhyrro): If the tree doesn't exist then error out.
     operations::Install::new(&tree, &config)

--- a/lux-cli/src/install_rockspec.rs
+++ b/lux-cli/src/install_rockspec.rs
@@ -81,11 +81,17 @@ pub async fn install_rockspec(data: InstallRockspec, config: Config) -> Result<(
             .wrap_err("error creating project lockfile.")?;
     }
 
-    build::Build::new(&rockspec, &tree, &config, &progress.map(|p| p.new_bar()))
-        .pin(pin)
-        .behaviour(BuildBehaviour::Force)
-        .build()
-        .await?;
+    build::Build::new(
+        &rockspec,
+        &tree,
+        true,
+        &config,
+        &progress.map(|p| p.new_bar()),
+    )
+    .pin(pin)
+    .behaviour(BuildBehaviour::Force)
+    .build()
+    .await?;
 
     Ok(())
 }

--- a/lux-cli/src/install_rockspec.rs
+++ b/lux-cli/src/install_rockspec.rs
@@ -66,6 +66,7 @@ pub async fn install_rockspec(data: InstallRockspec, config: Config) -> Result<(
                 BuildBehaviour::NoForce,
                 pin,
                 OptState::Required,
+                false,
             )
         });
 

--- a/lux-cli/src/install_rockspec.rs
+++ b/lux-cli/src/install_rockspec.rs
@@ -14,6 +14,7 @@ use lux_lib::{
     progress::MultiProgress,
     project::Project,
     rockspec::{LuaVersionCompatibility, Rockspec},
+    tree,
 };
 
 #[derive(Args, Default)]
@@ -66,7 +67,7 @@ pub async fn install_rockspec(data: InstallRockspec, config: Config) -> Result<(
                 BuildBehaviour::NoForce,
                 pin,
                 OptState::Required,
-                false,
+                tree::EntryType::DependencyOnly,
             )
         });
 
@@ -84,7 +85,7 @@ pub async fn install_rockspec(data: InstallRockspec, config: Config) -> Result<(
     build::Build::new(
         &rockspec,
         &tree,
-        true,
+        tree::EntryType::Entrypoint,
         &config,
         &progress.map(|p| p.new_bar()),
     )

--- a/lux-cli/src/lib.rs
+++ b/lux-cli/src/lib.rs
@@ -111,6 +111,10 @@ pub struct Cli {
     #[arg(long)]
     pub verbose: bool,
 
+    /// Configure lux for installing Neovim packages.
+    #[arg(long)]
+    pub nvim: bool,
+
     /// Timeout on network operations, in seconds.
     /// 0 means no timeout (wait forever). Default is 30.
     #[arg(long, value_name = "seconds")]

--- a/lux-cli/src/pack.rs
+++ b/lux-cli/src/pack.rs
@@ -11,7 +11,6 @@ use lux_lib::{
     package::PackageReq,
     progress::MultiProgress,
     project::Project,
-    tree::Tree,
 };
 use tempdir::TempDir;
 
@@ -71,13 +70,15 @@ pub async fn pack(args: Pack, config: Config) -> Result<()> {
             match default_tree.match_rocks(&package_req)? {
                 lux_lib::tree::RockMatches::NotFound(_) => {
                     let temp_dir = TempDir::new("lux-pack")?.into_path();
-                    let tree = Tree::new(temp_dir.clone(), lua_version.clone())?;
-                    let packages = Install::new(&tree, &config)
+                    let temp_config = config.with_tree(temp_dir);
+                    let tree = temp_config.tree(lua_version.clone())?;
+                    let packages = Install::new(&tree, &temp_config)
                         .package(PackageInstallSpec::new(
                             package_req,
                             BuildBehaviour::Force,
                             PinnedState::default(),
                             OptState::default(),
+                            true,
                         ))
                         .progress(progress)
                         .install()
@@ -119,8 +120,8 @@ pub async fn pack(args: Pack, config: Config) -> Result<()> {
             }?;
             let temp_dir = TempDir::new("lux-pack")?.into_path();
             let bar = progress.map(|p| p.new_bar());
-            let tree = Tree::new(temp_dir.clone(), lua_version.clone())?;
             let config = config.with_tree(temp_dir);
+            let tree = config.tree(lua_version)?;
             let package = Build::new(&rockspec, &tree, &config, &bar).build().await?;
             let rock_path = operations::Pack::new(dest_dir, tree, package).pack()?;
             Ok(rock_path)

--- a/lux-cli/src/pack.rs
+++ b/lux-cli/src/pack.rs
@@ -11,6 +11,7 @@ use lux_lib::{
     package::PackageReq,
     progress::MultiProgress,
     project::Project,
+    tree,
 };
 use tempdir::TempDir;
 
@@ -78,7 +79,7 @@ pub async fn pack(args: Pack, config: Config) -> Result<()> {
                             BuildBehaviour::Force,
                             PinnedState::default(),
                             OptState::default(),
-                            true,
+                            tree::EntryType::Entrypoint,
                         ))
                         .progress(progress)
                         .install()
@@ -122,7 +123,7 @@ pub async fn pack(args: Pack, config: Config) -> Result<()> {
             let bar = progress.map(|p| p.new_bar());
             let config = config.with_tree(temp_dir);
             let tree = config.tree(lua_version)?;
-            let package = Build::new(&rockspec, &tree, true, &config, &bar)
+            let package = Build::new(&rockspec, &tree, tree::EntryType::Entrypoint, &config, &bar)
                 .build()
                 .await?;
             let rock_path = operations::Pack::new(dest_dir, tree, package).pack()?;

--- a/lux-cli/src/pack.rs
+++ b/lux-cli/src/pack.rs
@@ -122,7 +122,9 @@ pub async fn pack(args: Pack, config: Config) -> Result<()> {
             let bar = progress.map(|p| p.new_bar());
             let config = config.with_tree(temp_dir);
             let tree = config.tree(lua_version)?;
-            let package = Build::new(&rockspec, &tree, &config, &bar).build().await?;
+            let package = Build::new(&rockspec, &tree, true, &config, &bar)
+                .build()
+                .await?;
             let rock_path = operations::Pack::new(dest_dir, tree, package).pack()?;
             Ok(rock_path)
         }

--- a/lux-cli/src/utils/install.rs
+++ b/lux-cli/src/utils/install.rs
@@ -35,7 +35,8 @@ pub fn apply_build_behaviour(
                 }
                 _ => Some(BuildBehaviour::from(force)),
             };
-            build_behaviour.map(|it| PackageInstallSpec::new(req, it, pin, OptState::Required))
+            build_behaviour
+                .map(|it| PackageInstallSpec::new(req, it, pin, OptState::Required, true))
         })
         .collect()
 }

--- a/lux-cli/src/utils/install.rs
+++ b/lux-cli/src/utils/install.rs
@@ -1,12 +1,13 @@
 //! Utilities for converting a list of packages into a list with the correct build behaviour.
 
+use eyre::Result;
 use inquire::Confirm;
 use lux_lib::{
     build::BuildBehaviour,
-    lockfile::{OptState, PinnedState},
+    lockfile::{LocalPackageId, OptState, PinnedState},
     operations::PackageInstallSpec,
     package::PackageReq,
-    tree::{RockMatches, Tree},
+    tree::{self, RockMatches, Tree},
 };
 
 pub fn apply_build_behaviour(
@@ -14,29 +15,45 @@ pub fn apply_build_behaviour(
     pin: PinnedState,
     force: bool,
     tree: &Tree,
-) -> Vec<PackageInstallSpec> {
-    package_reqs
+) -> Result<Vec<PackageInstallSpec>> {
+    let lockfile = tree.lockfile()?;
+    Ok(package_reqs
         .into_iter()
         .filter_map(|req| {
-            let build_behaviour: Option<BuildBehaviour> = match tree
+            let existing_packages: Vec<LocalPackageId> = match tree
                 .match_rocks_and(&req, |rock| pin == rock.pinned())
                 .expect("unable to get tree data")
             {
-                RockMatches::Single(_) | RockMatches::Many(_) if !force => {
-                    if Confirm::new(&format!("Package {} already exists. Overwrite?", req))
-                        .with_default(false)
-                        .prompt()
-                        .expect("Error prompting for reinstall")
-                    {
-                        Some(BuildBehaviour::Force)
-                    } else {
-                        None
-                    }
-                }
-                _ => Some(BuildBehaviour::from(force)),
+                RockMatches::Single(id) => vec![id],
+                RockMatches::Many(ids) => ids,
+                _ => Vec::new(),
             };
-            build_behaviour
-                .map(|it| PackageInstallSpec::new(req, it, pin, OptState::Required, true))
+            // NOTE: Because the rock layout may change, we must force a rebuild
+            // if a package is installed, but it is not an entrypoint.
+            let force = force
+                || existing_packages
+                    .iter()
+                    .all(|pkg_id| !lockfile.is_entrypoint(pkg_id));
+            let build_behaviour: Option<BuildBehaviour> = if force || existing_packages.is_empty() {
+                Some(BuildBehaviour::from(force))
+            } else if Confirm::new(&format!("Package {} already exists. Overwrite?", req))
+                .with_default(false)
+                .prompt()
+                .expect("Error prompting for reinstall")
+            {
+                Some(BuildBehaviour::Force)
+            } else {
+                None
+            };
+            build_behaviour.map(|it| {
+                PackageInstallSpec::new(
+                    req,
+                    it,
+                    pin,
+                    OptState::Required,
+                    tree::EntryType::Entrypoint,
+                )
+            })
         })
-        .collect()
+        .collect())
 }

--- a/lux-lib/resources/test/lux.lock
+++ b/lux-lib/resources/test/lux.lock
@@ -22,46 +22,6 @@
           "source": "sha256-cJ2EfkbTOiEJ8IPVnoO77alXynBv+nJ2ql/vfYOTSJI="
         }
       },
-      "09b728b8ffb1b864e2002cec989c47a30ccb3d92dfea356667e576e0329b8d84": {
-        "name": "neorg",
-        "version": "8.0.0-1",
-        "pinned": false,
-        "opt": false,
-        "dependencies": [
-          "de206edd51dbfc1bbe56869d6729cf4a6e6e70e7b2e107093c0f6520c142d79b",
-          "41690f14b6a1b68141de9ea50093a18e76437b931fac8b7bd464d95c2f187321"
-        ],
-        "constraint": "=8.0.0",
-        "binaries": [],
-        "source": "luarocks_rockspec+https://luarocks.org/",
-        "source_url": {
-          "type": "url",
-          "url": "https://github.com/nvim-neorg/neorg/archive/v8.0.0.zip"
-        },
-        "hashes": {
-          "rockspec": "sha256-7FQ1jtFfZQQ9IYtLwS14TcFsTWXM4xMnnpQh80GHpP0=",
-          "source": "sha256-YRQaq7LRoIK6qrc1djC/z4aPVhdcuw1IKxsZuddJKu4="
-        }
-      },
-      "0e7601c45f13611fa5b85cb3ba46a554ad6fb6c4546776b310c9ebfc5581e663": {
-        "name": "say",
-        "version": "1.4.1-3",
-        "pinned": false,
-        "opt": false,
-        "dependencies": [],
-        "constraint": null,
-        "binaries": [],
-        "source": "luarocks_rockspec+https://luarocks.org/",
-        "source_url": {
-          "type": "git",
-          "url": "https://github.com/lunarmodules/say.git",
-          "ref": "v1.4.1"
-        },
-        "hashes": {
-          "rockspec": "sha256-WFKt1iWeyjO9A8SG0KUX8tkS9JvMqoVM8CKBUguuK0Y=",
-          "source": "sha256-IjNkK1leVtYgbEjUqguVMjbdW+0BHAOCE0pazrVuF50="
-        }
-      },
       "33b61cf80f923edb9bb666545d5fc2eede97156d0f903d330b5d737e8635ae0b": {
         "name": "nui.nvim",
         "version": "0.3.0-1",
@@ -278,8 +238,6 @@
       }
     },
     "entrypoints": [
-      "09b728b8ffb1b864e2002cec989c47a30ccb3d92dfea356667e576e0329b8d84",
-      "0e7601c45f13611fa5b85cb3ba46a554ad6fb6c4546776b310c9ebfc5581e663",
       "6ce52e817fcd2ffa42a18cff12c0fe8c94bc9fdddc62ff0592d1ce7934876e4d",
       "6e71c27e2818df16fdbf782b88dca9199cd20b29a88a7af29cb5c1c87cb03f95"
     ]

--- a/lux-lib/src/build/mod.rs
+++ b/lux-lib/src/build/mod.rs
@@ -72,10 +72,6 @@ pub struct Build<'a, R: Rockspec + HasIntegrity> {
     #[builder(default)]
     behaviour: BuildBehaviour,
 
-    /// Whether to install `etc` and `doc` directories.
-    #[builder(default = true)]
-    install_etc: bool,
-
     // TODO(vhyrro): Remove this and enforce that this is provided at a type level.
     source: Option<RemotePackageSource>,
 }
@@ -385,25 +381,20 @@ async fn do_build<R: Rockspec + HasIntegrity>(
             )
             .await?;
 
-            if build.install_etc {
-                for directory in rockspec
-                    .build()
-                    .current_platform()
-                    .copy_directories
-                    .iter()
-                    .filter(|dir| {
-                        dir.file_name()
-                            .is_some_and(|name| name != "doc" && name != "docs")
-                    })
-                {
-                    recursive_copy_dir(
-                        &build_dir.join(directory),
-                        &output_paths.etc.join(directory),
-                    )?;
-                }
-
-                recursive_copy_doc_dir(&output_paths, &build_dir)?;
+            for directory in rockspec
+                .build()
+                .current_platform()
+                .copy_directories
+                .iter()
+                .filter(|dir| {
+                    dir.file_name()
+                        .is_some_and(|name| name != "doc" && name != "docs")
+                })
+            {
+                recursive_copy_dir(&build_dir.join(directory), &output_paths.etc)?;
             }
+
+            recursive_copy_doc_dir(&output_paths, &build_dir)?;
 
             std::fs::write(
                 output_paths.rockspec_path(),

--- a/lux-lib/src/build/mod.rs
+++ b/lux-lib/src/build/mod.rs
@@ -55,6 +55,8 @@ pub struct Build<'a, R: Rockspec + HasIntegrity> {
     #[builder(start_fn)]
     tree: &'a Tree,
     #[builder(start_fn)]
+    is_entrypoint: bool,
+    #[builder(start_fn)]
     config: &'a Config,
 
     #[builder(start_fn)]
@@ -329,7 +331,11 @@ async fn do_build<R: Rockspec + HasIntegrity>(
     match tree.lockfile()?.get(&package.id()) {
         Some(package) if build.behaviour == BuildBehaviour::NoForce => Ok(package.clone()),
         _ => {
-            let output_paths = tree.rock(&package)?;
+            let output_paths = if build.is_entrypoint {
+                tree.entrypoint(&package)?
+            } else {
+                tree.dependency(&package)?
+            };
 
             let lua = LuaInstallation::new(&lua_version, build.config);
 

--- a/lux-lib/src/config/mod.rs
+++ b/lux-lib/src/config/mod.rs
@@ -258,7 +258,7 @@ impl Config {
     pub fn test_tree(&self, version: LuaVersion) -> io::Result<Tree> {
         let tree = self.tree(version.clone())?;
         let test_tree_root = tree.root().join("test_dependencies");
-        Ok(Tree::new(test_tree_root, version, self)?)
+        Tree::new(test_tree_root, version, self)
     }
 
     /// The tree in which to install luarocks for use as a compatibility layer

--- a/lux-lib/src/config/mod.rs
+++ b/lux-lib/src/config/mod.rs
@@ -180,9 +180,9 @@ pub struct Config {
     timeout: Duration,
     variables: HashMap<String, String>,
     external_deps: ExternalDependencySearchConfig,
-    /// The rock layout for new install trees.
-    /// Does not affect existing install trees.
-    rock_layout: RockLayoutConfig,
+    /// The rock layout for entrypoints of new install trees.
+    /// Does not affect existing install trees or dependency rock layouts.
+    entrypoint_layout: RockLayoutConfig,
 
     cache_dir: PathBuf,
     data_dir: PathBuf,
@@ -300,8 +300,8 @@ impl Config {
         &self.external_deps
     }
 
-    pub fn rock_layout(&self) -> &RockLayoutConfig {
-        &self.rock_layout
+    pub fn entrypoint_layout(&self) -> &RockLayoutConfig {
+        &self.entrypoint_layout
     }
 
     pub fn cache_dir(&self) -> &PathBuf {
@@ -365,7 +365,7 @@ pub struct ConfigBuilder {
     /// The rock layout for new install trees.
     /// Does not affect existing install trees.
     #[serde(default)]
-    rock_layout: RockLayoutConfig,
+    entrypoint_layout: RockLayoutConfig,
 }
 
 impl ConfigBuilder {
@@ -458,9 +458,9 @@ impl ConfigBuilder {
         Self { data_dir, ..self }
     }
 
-    pub fn rock_layout(self, rock_layout: RockLayoutConfig) -> Self {
+    pub fn entrypoint_layout(self, rock_layout: RockLayoutConfig) -> Self {
         Self {
-            rock_layout,
+            entrypoint_layout: rock_layout,
             ..self
         }
     }
@@ -508,7 +508,7 @@ impl ConfigBuilder {
                 .chain(self.variables.unwrap_or_default())
                 .collect(),
             external_deps: self.external_deps,
-            rock_layout: self.rock_layout,
+            entrypoint_layout: self.entrypoint_layout,
             cache_dir,
             data_dir,
         })
@@ -535,7 +535,7 @@ impl From<Config> for ConfigBuilder {
             cache_dir: Some(value.cache_dir),
             data_dir: Some(value.data_dir),
             external_deps: value.external_deps,
-            rock_layout: value.rock_layout,
+            entrypoint_layout: value.entrypoint_layout,
         }
     }
 }

--- a/lux-lib/src/config/mod.rs
+++ b/lux-lib/src/config/mod.rs
@@ -7,6 +7,7 @@ use std::{
     collections::HashMap, env, fmt::Display, io, path::PathBuf, str::FromStr, time::Duration,
 };
 use thiserror::Error;
+use tree::RockLayoutConfig;
 use url::Url;
 
 use crate::rockspec::LuaVersionCompatibility;
@@ -21,6 +22,7 @@ use crate::{
 };
 
 pub mod external_deps;
+pub mod tree;
 
 const DEV_PATH: &str = "dev/";
 
@@ -178,6 +180,9 @@ pub struct Config {
     timeout: Duration,
     variables: HashMap<String, String>,
     external_deps: ExternalDependencySearchConfig,
+    /// The rock layout for new install trees.
+    /// Does not affect existing install trees.
+    rock_layout: RockLayoutConfig,
 
     cache_dir: PathBuf,
     data_dir: PathBuf,
@@ -247,7 +252,13 @@ impl Config {
     }
 
     pub fn tree(&self, version: LuaVersion) -> io::Result<Tree> {
-        Tree::new(self.tree.clone(), version)
+        Tree::new(self.tree.clone(), version, self)
+    }
+
+    pub fn test_tree(&self, version: LuaVersion) -> io::Result<Tree> {
+        let tree = self.tree(version.clone())?;
+        let test_tree_root = tree.root().join("test_dependencies");
+        Ok(Tree::new(test_tree_root, version, self)?)
     }
 
     /// The tree in which to install luarocks for use as a compatibility layer
@@ -287,6 +298,10 @@ impl Config {
 
     pub fn external_deps(&self) -> &ExternalDependencySearchConfig {
         &self.external_deps
+    }
+
+    pub fn rock_layout(&self) -> &RockLayoutConfig {
+        &self.rock_layout
     }
 
     pub fn cache_dir(&self) -> &PathBuf {
@@ -347,6 +362,10 @@ pub struct ConfigBuilder {
     variables: Option<HashMap<String, String>>,
     #[serde(default)]
     external_deps: ExternalDependencySearchConfig,
+    /// The rock layout for new install trees.
+    /// Does not affect existing install trees.
+    #[serde(default)]
+    rock_layout: RockLayoutConfig,
 }
 
 impl ConfigBuilder {
@@ -439,6 +458,13 @@ impl ConfigBuilder {
         Self { data_dir, ..self }
     }
 
+    pub fn rock_layout(self, rock_layout: RockLayoutConfig) -> Self {
+        Self {
+            rock_layout,
+            ..self
+        }
+    }
+
     pub fn build(self) -> Result<Config, ConfigError> {
         let data_dir = self.data_dir.unwrap_or(Config::get_default_data_path()?);
         let cache_dir = self.cache_dir.unwrap_or(Config::get_default_cache_path()?);
@@ -482,6 +508,7 @@ impl ConfigBuilder {
                 .chain(self.variables.unwrap_or_default())
                 .collect(),
             external_deps: self.external_deps,
+            rock_layout: self.rock_layout,
             cache_dir,
             data_dir,
         })
@@ -508,6 +535,7 @@ impl From<Config> for ConfigBuilder {
             cache_dir: Some(value.cache_dir),
             data_dir: Some(value.data_dir),
             external_deps: value.external_deps,
+            rock_layout: value.rock_layout,
         }
     }
 }

--- a/lux-lib/src/config/tree.rs
+++ b/lux-lib/src/config/tree.rs
@@ -1,0 +1,59 @@
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// Template configuration for a rock's tree layout
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+pub struct RockLayoutConfig {
+    /// The root of a packages `etc` directory.
+    /// If unset (the default), the root is the package root.
+    /// If set, it is a directory relative to the given Lua version's install tree root.
+    /// With the `--nvim` preset, this is `site/pack/lux`.
+    pub(crate) etc_root: Option<PathBuf>,
+    /// The `etc` directory for non-optional packages
+    /// Default: `etc` With the `--nvim` preset, this is `start`
+    /// Note: If `etc_root` is set, the package ID is appended.
+    pub(crate) etc: PathBuf,
+    /// The `etc` directory for optional packages
+    /// Default: `etc`
+    /// With the `--nvim` preset, this is `opt`
+    /// Note: If `etc_root` is set, the package ID is appended.
+    pub(crate) opt_etc: PathBuf,
+    /// The `conf` directory name
+    /// Default: `conf`
+    pub(crate) conf: PathBuf,
+    /// The `doc` directory name
+    /// Default: `doc`
+    pub(crate) doc: PathBuf,
+}
+
+impl RockLayoutConfig {
+    /// Creates a `RockLayoutConfig` for use with Neovim
+    /// - `etc_root`: `site/pack/lux`
+    /// - `etc`: `start`
+    /// - `opt_etc`: `opt`
+    pub fn new_nvim_layout() -> Self {
+        Self {
+            etc_root: Some("site/pack/lux".into()),
+            etc: "start".into(),
+            opt_etc: "opt".into(),
+            conf: "conf".into(),
+            doc: "doc".into(),
+        }
+    }
+
+    pub(crate) fn is_default(&self) -> bool {
+        &Self::default() == self
+    }
+}
+
+impl Default for RockLayoutConfig {
+    fn default() -> Self {
+        Self {
+            etc_root: None,
+            etc: "etc".into(),
+            opt_etc: "etc".into(),
+            conf: "conf".into(),
+            doc: "doc".into(),
+        }
+    }
+}

--- a/lux-lib/src/lockfile/mod.rs
+++ b/lux-lib/src/lockfile/mod.rs
@@ -100,8 +100,6 @@ impl<'de> Deserialize<'de> for PinnedState {
     }
 }
 
-/// For now, this doesn't have much meaning.
-/// It may be used later.
 #[derive(Copy, Debug, PartialEq, Eq, Hash, Clone, PartialOrd, Ord)]
 pub enum OptState {
     /// A required package
@@ -854,6 +852,10 @@ impl<P: LockfilePermissions> Lockfile<P> {
         self.lock.is_entrypoint(package)
     }
 
+    pub fn entry_type(&self, package: &LocalPackageId) -> bool {
+        self.lock.is_entrypoint(package)
+    }
+
     pub(crate) fn local_pkg_lock(&self) -> &LocalPackageLock {
         &self.lock
     }
@@ -963,7 +965,11 @@ impl<P: LockfilePermissions> ProjectLockfile<P> {
         }
     }
 
-    pub fn is_entrypoint(&self, package: &LocalPackageId, deps: &LocalPackageLockType) -> bool {
+    pub(crate) fn is_entrypoint(
+        &self,
+        package: &LocalPackageId,
+        deps: &LocalPackageLockType,
+    ) -> bool {
         match deps {
             LocalPackageLockType::Regular => self.dependencies.is_entrypoint(package),
             LocalPackageLockType::Test => self.test_dependencies.is_entrypoint(package),

--- a/lux-lib/src/lockfile/mod.rs
+++ b/lux-lib/src/lockfile/mod.rs
@@ -784,7 +784,7 @@ pub struct Lockfile<P: LockfilePermissions> {
     #[serde(flatten)]
     lock: LocalPackageLock,
     #[serde(default, skip_serializing_if = "RockLayoutConfig::is_default")]
-    pub(crate) rock_layout: RockLayoutConfig,
+    pub(crate) entrypoint_layout: RockLayoutConfig,
 }
 
 pub(crate) enum LocalPackageLockType {
@@ -1006,7 +1006,7 @@ impl Lockfile<ReadOnly> {
                     _marker: PhantomData,
                     version: LOCKFILE_VERSION_STR.into(),
                     lock: LocalPackageLock::default(),
-                    rock_layout: rock_layout.clone(),
+                    entrypoint_layout: rock_layout.clone(),
                 };
                 let json_str = serde_json::to_string(&empty_lockfile)?;
                 write!(file, "{}", json_str)?;
@@ -1028,7 +1028,7 @@ impl Lockfile<ReadOnly> {
             serde_json::from_str(&std::fs::read_to_string(&filepath)?)?;
         lockfile.filepath = filepath;
         if let Some(expected_rock_layout) = expected_rock_layout {
-            if &lockfile.rock_layout != expected_rock_layout {
+            if &lockfile.entrypoint_layout != expected_rock_layout {
                 return Err(io::Error::other(
                     "attempt to a lockfile that does not match the expected rock layout.",
                 ));
@@ -1044,7 +1044,7 @@ impl Lockfile<ReadOnly> {
             filepath: self.filepath,
             version: self.version,
             lock: self.lock,
-            rock_layout: self.rock_layout,
+            entrypoint_layout: self.entrypoint_layout,
         }
     }
 

--- a/lux-lib/src/lockfile/mod.rs
+++ b/lux-lib/src/lockfile/mod.rs
@@ -652,7 +652,7 @@ impl LocalPackageLock {
     }
 
     fn is_entrypoint(&self, package: &LocalPackageId) -> bool {
-        self.entrypoints.contains(&package)
+        self.entrypoints.contains(package)
     }
 
     fn list(&self) -> HashMap<PackageName, Vec<LocalPackage>> {
@@ -960,6 +960,14 @@ impl<P: LockfilePermissions> ProjectLockfile<P> {
             LocalPackageLockType::Regular => self.dependencies.get(id),
             LocalPackageLockType::Test => self.test_dependencies.get(id),
             LocalPackageLockType::Build => self.build_dependencies.get(id),
+        }
+    }
+
+    pub fn is_entrypoint(&self, package: &LocalPackageId, deps: &LocalPackageLockType) -> bool {
+        match deps {
+            LocalPackageLockType::Regular => self.dependencies.is_entrypoint(package),
+            LocalPackageLockType::Test => self.test_dependencies.is_entrypoint(package),
+            LocalPackageLockType::Build => self.build_dependencies.is_entrypoint(package),
         }
     }
 

--- a/lux-lib/src/lockfile/snapshots/lux_lib__lockfile__tests__add_rocks.snap
+++ b/lux-lib/src/lockfile/snapshots/lux_lib__lockfile__tests__add_rocks.snap
@@ -1,6 +1,6 @@
 ---
 source: lux-lib/src/lockfile/mod.rs
-assertion_line: 1514
+assertion_line: 1484
 expression: lockfile
 ---
 {
@@ -317,6 +317,7 @@ expression: lockfile
     "09b728b8ffb1b864e2002cec989c47a30ccb3d92dfea356667e576e0329b8d84",
     "0e7601c45f13611fa5b85cb3ba46a554ad6fb6c4546776b310c9ebfc5581e663",
     "6ce52e817fcd2ffa42a18cff12c0fe8c94bc9fdddc62ff0592d1ce7934876e4d",
-    "6e71c27e2818df16fdbf782b88dca9199cd20b29a88a7af29cb5c1c87cb03f95"
+    "6e71c27e2818df16fdbf782b88dca9199cd20b29a88a7af29cb5c1c87cb03f95",
+    "9aee9941c7f659d37f722216138a3913b8861f8d31d52da5601a39d9a30e9d4e"
   ]
 }

--- a/lux-lib/src/luarocks/install_binary_rock.rs
+++ b/lux-lib/src/luarocks/install_binary_rock.rs
@@ -53,7 +53,6 @@ pub(crate) struct BinaryRockInstall<'a> {
     behaviour: BuildBehaviour,
     config: &'a Config,
     progress: &'a Progress<ProgressBar>,
-    install_etc: bool,
 }
 
 impl<'a> BinaryRockInstall<'a> {
@@ -74,7 +73,6 @@ impl<'a> BinaryRockInstall<'a> {
             behaviour: BuildBehaviour::default(),
             pin: PinnedState::default(),
             opt: OptState::default(),
-            install_etc: true,
         }
     }
 
@@ -92,13 +90,6 @@ impl<'a> BinaryRockInstall<'a> {
 
     pub(crate) fn behaviour(self, behaviour: BuildBehaviour) -> Self {
         Self { behaviour, ..self }
-    }
-
-    pub(crate) fn install_etc(self, install_etc: bool) -> Self {
-        Self {
-            install_etc,
-            ..self
-        }
     }
 
     pub(crate) async fn install(self) -> Result<LocalPackage, InstallBinaryRockError> {
@@ -167,18 +158,16 @@ impl<'a> BinaryRockInstall<'a> {
                     &unpack_dir.join("bin"),
                     &output_paths.bin,
                 )?;
-                if self.install_etc {
-                    install_manifest_entries(
-                        &rock_manifest.doc.entries,
-                        &unpack_dir.join("doc"),
-                        &output_paths.doc,
-                    )?;
-                    install_manifest_entries(
-                        &rock_manifest.root.entries,
-                        &unpack_dir,
-                        &output_paths.etc,
-                    )?;
-                }
+                install_manifest_entries(
+                    &rock_manifest.doc.entries,
+                    &unpack_dir.join("doc"),
+                    &output_paths.doc,
+                )?;
+                install_manifest_entries(
+                    &rock_manifest.root.entries,
+                    &unpack_dir,
+                    &output_paths.etc,
+                )?;
                 // rename <name>-<version>.rockspec
                 let rockspec_path = output_paths.etc.join(format!(
                     "{}-{}.rockspec",
@@ -274,7 +263,7 @@ mod test {
         .await
         .unwrap();
         let tree = config.tree(LuaVersion::from(&config).unwrap()).unwrap();
-        let installed_rock_layout = tree.rock_layout(&local_package);
+        let installed_rock_layout = tree.rock_layout(&local_package).unwrap();
         let orig_install_tree_integrity = installed_rock_layout.rock_path.hash().unwrap();
 
         let pack_dest_dir = assert_fs::TempDir::new().unwrap();
@@ -329,7 +318,7 @@ mod test {
         .install()
         .await
         .unwrap();
-        let installed_rock_layout = tree.rock_layout(&local_package);
+        let installed_rock_layout = tree.rock_layout(&local_package).unwrap();
         assert!(installed_rock_layout.rockspec_path().is_file());
         let new_install_tree_integrity = installed_rock_layout.rock_path.hash().unwrap();
         assert_eq!(orig_install_tree_integrity, new_install_tree_integrity);

--- a/lux-lib/src/luarocks/luarocks_installation.rs
+++ b/lux-lib/src/luarocks/luarocks_installation.rs
@@ -115,7 +115,7 @@ impl LuaRocksInstallation {
 
         if !self.tree.match_rocks(&luarocks_req)?.is_found() {
             let rockspec = RemoteLuaRockspec::new(LUAROCKS_ROCKSPEC).unwrap();
-            let pkg = Build::new(&rockspec, &self.tree, &self.config, progress)
+            let pkg = Build::new(&rockspec, &self.tree, true, &self.config, progress)
                 .constraint(luarocks_req.version_req().clone().into())
                 .build()
                 .await?;
@@ -189,7 +189,7 @@ impl LuaRocksInstallation {
             let tree = self.tree.clone();
             tokio::spawn(async move {
                 let rockspec = install_spec.downloaded_rock.rockspec();
-                let pkg = Build::new(rockspec, &tree, &config, &bar)
+                let pkg = Build::new(rockspec, &tree, true, &config, &bar)
                     .constraint(install_spec.spec.constraint())
                     .behaviour(install_spec.build_behaviour)
                     .build()

--- a/lux-lib/src/luarocks/luarocks_installation.rs
+++ b/lux-lib/src/luarocks/luarocks_installation.rs
@@ -192,7 +192,6 @@ impl LuaRocksInstallation {
                 let pkg = Build::new(rockspec, &tree, &config, &bar)
                     .constraint(install_spec.spec.constraint())
                     .behaviour(install_spec.build_behaviour)
-                    .install_etc(install_spec.is_entrypoint)
                     .build()
                     .await?;
 

--- a/lux-lib/src/operations/install.rs
+++ b/lux-lib/src/operations/install.rs
@@ -246,6 +246,7 @@ async fn install_impl(
                         install_spec.build_behaviour,
                         install_spec.pin,
                         install_spec.opt,
+                        install_spec.is_entrypoint,
                         &tree,
                         &config,
                         progress_arc,
@@ -263,6 +264,7 @@ async fn install_impl(
                         install_spec.build_behaviour,
                         install_spec.pin,
                         install_spec.opt,
+                        install_spec.is_entrypoint,
                         &config,
                         progress_arc,
                     )
@@ -328,6 +330,7 @@ async fn install_rockspec(
     behaviour: BuildBehaviour,
     pin: PinnedState,
     opt: OptState,
+    is_entrypoint: bool,
     tree: &Tree,
     config: &Config,
     progress_arc: Arc<Progress<MultiProgress>>,
@@ -348,7 +351,7 @@ async fn install_rockspec(
             .await?;
     }
 
-    let pkg = Build::new(&rockspec, tree, config, &bar)
+    let pkg = Build::new(&rockspec, tree, is_entrypoint, config, &bar)
         .pin(pin)
         .opt(opt)
         .constraint(constraint)
@@ -372,6 +375,7 @@ async fn install_binary_rock(
     behaviour: BuildBehaviour,
     pin: PinnedState,
     opt: OptState,
+    is_entrypoint: bool,
     config: &Config,
     progress_arc: Arc<Progress<MultiProgress>>,
 ) -> Result<LocalPackage, InstallError> {
@@ -388,6 +392,7 @@ async fn install_binary_rock(
         &rockspec,
         rockspec_download.source,
         packed_rock,
+        is_entrypoint,
         config,
         &bar,
     )

--- a/lux-lib/src/operations/install.rs
+++ b/lux-lib/src/operations/install.rs
@@ -338,7 +338,6 @@ async fn install_rockspec(
         .opt(opt)
         .constraint(constraint)
         .behaviour(behaviour)
-        .install_etc(is_entrypoint)
         .source(source)
         .source_url(rockspec_download.source_url)
         .build()
@@ -382,7 +381,6 @@ async fn install_binary_rock(
     .opt(opt)
     .constraint(constraint)
     .behaviour(behaviour)
-    .install_etc(is_entrypoint)
     .install()
     .await
     .map_err(|err| InstallError::InstallBinaryRockError(package, err))?;

--- a/lux-lib/src/operations/install_spec.rs
+++ b/lux-lib/src/operations/install_spec.rs
@@ -2,6 +2,7 @@ use crate::{
     build::BuildBehaviour,
     lockfile::{OptState, PinnedState},
     package::PackageReq,
+    tree,
 };
 
 /// Specifies how to install a package
@@ -10,7 +11,7 @@ pub struct PackageInstallSpec {
     pub(crate) build_behaviour: BuildBehaviour,
     pub(crate) pin: PinnedState,
     pub(crate) opt: OptState,
-    pub(crate) is_entrypoint: bool,
+    pub(crate) entry_type: tree::EntryType,
 }
 
 impl PackageInstallSpec {
@@ -19,14 +20,14 @@ impl PackageInstallSpec {
         build_behaviour: BuildBehaviour,
         pin: PinnedState,
         opt: OptState,
-        is_entrypoint: bool,
+        entry_type: tree::EntryType,
     ) -> Self {
         Self {
             package,
             build_behaviour,
             pin,
             opt,
-            is_entrypoint,
+            entry_type,
         }
     }
 }

--- a/lux-lib/src/operations/install_spec.rs
+++ b/lux-lib/src/operations/install_spec.rs
@@ -2,7 +2,6 @@ use crate::{
     build::BuildBehaviour,
     lockfile::{OptState, PinnedState},
     package::PackageReq,
-    rockspec::lua_dependency::LuaDependencySpec,
 };
 
 /// Specifies how to install a package
@@ -11,6 +10,7 @@ pub struct PackageInstallSpec {
     pub(crate) build_behaviour: BuildBehaviour,
     pub(crate) pin: PinnedState,
     pub(crate) opt: OptState,
+    pub(crate) is_entrypoint: bool,
 }
 
 impl PackageInstallSpec {
@@ -19,34 +19,14 @@ impl PackageInstallSpec {
         build_behaviour: BuildBehaviour,
         pin: PinnedState,
         opt: OptState,
+        is_entrypoint: bool,
     ) -> Self {
         Self {
             package,
             build_behaviour,
             pin,
             opt,
-        }
-    }
-}
-
-impl From<PackageReq> for PackageInstallSpec {
-    fn from(package: PackageReq) -> Self {
-        Self {
-            package,
-            build_behaviour: BuildBehaviour::default(),
-            pin: PinnedState::default(),
-            opt: OptState::default(),
-        }
-    }
-}
-
-impl From<LuaDependencySpec> for PackageInstallSpec {
-    fn from(value: LuaDependencySpec) -> Self {
-        Self {
-            package: value.package_req,
-            build_behaviour: BuildBehaviour::default(),
-            pin: value.pin,
-            opt: value.opt,
+            is_entrypoint,
         }
     }
 }

--- a/lux-lib/src/operations/pack.rs
+++ b/lux-lib/src/operations/pack.rs
@@ -61,7 +61,7 @@ pub enum PackError {
 fn do_pack(args: Pack) -> Result<PathBuf, PackError> {
     let package = args.package;
     let tree = args.tree;
-    let layout = tree.rock_layout(&package);
+    let layout = tree.rock_layout(&package)?;
     let suffix = if is_binary_rock(&layout) {
         format!("{}.rock", luarocks::current_platform_luarocks_identifier())
     } else {

--- a/lux-lib/src/operations/pack.rs
+++ b/lux-lib/src/operations/pack.rs
@@ -61,7 +61,7 @@ pub enum PackError {
 fn do_pack(args: Pack) -> Result<PathBuf, PackError> {
     let package = args.package;
     let tree = args.tree;
-    let layout = tree.rock_layout(&package)?;
+    let layout = tree.entrypoint_layout(&package);
     let suffix = if is_binary_rock(&layout) {
         format!("{}.rock", luarocks::current_platform_luarocks_identifier())
     } else {

--- a/lux-lib/src/operations/remove.rs
+++ b/lux-lib/src/operations/remove.rs
@@ -117,7 +117,9 @@ async fn remove_package(
         ))
     });
 
-    tokio::fs::remove_dir_all(tree.root_for(&package)).await?;
+    let rock_layout = tree.rock_layout(&package);
+    tokio::fs::remove_dir_all(&rock_layout.etc).await?;
+    tokio::fs::remove_dir_all(&rock_layout.rock_path).await?;
 
     // Delete the corresponding binaries attached to the current package (located under `{LUX_TREE}/bin/`)
     for relative_binary_path in package.spec.binaries() {

--- a/lux-lib/src/operations/remove.rs
+++ b/lux-lib/src/operations/remove.rs
@@ -117,7 +117,7 @@ async fn remove_package(
         ))
     });
 
-    let rock_layout = tree.rock_layout(&package);
+    let rock_layout = tree.rock_layout(&package)?;
     tokio::fs::remove_dir_all(&rock_layout.etc).await?;
     tokio::fs::remove_dir_all(&rock_layout.rock_path).await?;
 

--- a/lux-lib/src/operations/remove.rs
+++ b/lux-lib/src/operations/remove.rs
@@ -117,7 +117,7 @@ async fn remove_package(
         ))
     });
 
-    let rock_layout = tree.rock_layout(&package)?;
+    let rock_layout = tree.installed_rock_layout(&package)?;
     tokio::fs::remove_dir_all(&rock_layout.etc).await?;
     tokio::fs::remove_dir_all(&rock_layout.rock_path).await?;
 

--- a/lux-lib/src/operations/resolve.rs
+++ b/lux-lib/src/operations/resolve.rs
@@ -25,6 +25,7 @@ pub(crate) struct PackageInstallData {
     pub opt: OptState,
     pub downloaded_rock: RemoteRockDownload,
     pub spec: LocalPackageSpec,
+    pub is_entrypoint: bool,
 }
 
 #[async_recursion]
@@ -60,6 +61,7 @@ where
                      build_behaviour,
                      pin,
                      opt,
+                     is_entrypoint,
                  }| {
                     let config = config.clone();
                     let tx = tx.clone();
@@ -83,11 +85,14 @@ where
                             .current_platform()
                             .iter()
                             .filter(|dep| !dep.name().eq(&"lua".into()))
-                            .map(|dep| PackageInstallSpec {
-                                package: dep.package_req().clone(),
-                                build_behaviour,
-                                pin,
-                                opt,
+                            .map(|dep| {
+                                PackageInstallSpec::new(
+                                    dep.package_req().clone(),
+                                    build_behaviour,
+                                    pin,
+                                    opt,
+                                    false,
+                                )
                             })
                             .collect_vec();
 
@@ -118,6 +123,7 @@ where
                             opt,
                             spec: local_spec.clone(),
                             downloaded_rock,
+                            is_entrypoint,
                         };
 
                         tx.send(install_spec).unwrap();

--- a/lux-lib/src/operations/run.rs
+++ b/lux-lib/src/operations/run.rs
@@ -1,7 +1,9 @@
 use std::{io, process::Command};
 
 use crate::{
+    build::BuildBehaviour,
     config::{Config, LuaVersion, LuaVersionUnset},
+    lockfile::{OptState, PinnedState},
     lua_rockspec::LuaVersionError,
     operations::Install,
     package::{PackageReq, PackageVersionReqError},
@@ -13,7 +15,7 @@ use bon::Builder;
 use itertools::Itertools;
 use thiserror::Error;
 
-use super::InstallError;
+use super::{InstallError, PackageInstallSpec};
 
 /// Rocks package runner, providing fine-grained control
 /// over how a package should be run.
@@ -111,9 +113,15 @@ pub enum InstallCmdError {
 /// Ensure that a command is installed.
 /// This defaults to the local project tree if cwd is a project root.
 pub async fn install_command(command: &str, config: &Config) -> Result<(), InstallCmdError> {
-    let package_req = PackageReq::new(command.into(), None)?;
+    let install_spec = PackageInstallSpec::new(
+        PackageReq::new(command.into(), None)?,
+        BuildBehaviour::default(),
+        PinnedState::default(),
+        OptState::default(),
+        true,
+    );
     Install::new(&config.tree(LuaVersion::from(config)?)?, config)
-        .package(package_req.into())
+        .package(install_spec)
         .install()
         .await?;
     Ok(())

--- a/lux-lib/src/operations/run.rs
+++ b/lux-lib/src/operations/run.rs
@@ -10,6 +10,7 @@ use crate::{
     path::Paths,
     project::{Project, ProjectTreeError},
     remote_package_db::RemotePackageDBError,
+    tree,
 };
 use bon::Builder;
 use itertools::Itertools;
@@ -118,7 +119,7 @@ pub async fn install_command(command: &str, config: &Config) -> Result<(), Insta
         BuildBehaviour::default(),
         PinnedState::default(),
         OptState::default(),
-        true,
+        tree::EntryType::Entrypoint,
     );
     Install::new(&config.tree(LuaVersion::from(config)?)?, config)
         .package(install_spec)

--- a/lux-lib/src/operations/sync.rs
+++ b/lux-lib/src/operations/sync.rs
@@ -158,6 +158,7 @@ async fn do_sync(
                 BuildBehaviour::Force,
                 pkg.pinned(),
                 pkg.opt(),
+                true,
             )
         })
         .collect_vec();
@@ -211,6 +212,7 @@ async fn do_sync(
                 BuildBehaviour::Force,
                 *pkg.pin(),
                 *pkg.opt(),
+                true,
             )
         });
 

--- a/lux-lib/src/operations/test.rs
+++ b/lux-lib/src/operations/test.rs
@@ -9,7 +9,7 @@ use crate::{
     progress::{MultiProgress, Progress},
     project::{project_toml::LocalProjectTomlValidationError, Project, ProjectTreeError},
     rockspec::Rockspec,
-    tree::Tree,
+    tree::{self, Tree},
 };
 use bon::Builder;
 use itertools::Itertools;
@@ -195,7 +195,7 @@ pub async fn ensure_busted(
             BuildBehaviour::default(),
             PinnedState::default(),
             OptState::default(),
-            true,
+            tree::EntryType::Entrypoint,
         );
         Install::new(tree, config)
             .package(install_spec)
@@ -237,7 +237,7 @@ async fn ensure_dependencies(
                     build_behaviour,
                     *dep.pin(),
                     *dep.opt(),
-                    true,
+                    tree::EntryType::Entrypoint,
                 )
             })
         });
@@ -268,7 +268,7 @@ async fn ensure_dependencies(
                     build_behaviour,
                     *dep.pin(),
                     *dep.opt(),
-                    true,
+                    tree::EntryType::Entrypoint,
                 )
             })
         });

--- a/lux-lib/src/operations/test.rs
+++ b/lux-lib/src/operations/test.rs
@@ -3,6 +3,7 @@ use std::{io, ops::Deref, process::Command, sync::Arc};
 use crate::{
     build::BuildBehaviour,
     config::Config,
+    lockfile::{OptState, PinnedState},
     package::{PackageName, PackageReq, PackageVersionReqError},
     path::Paths,
     progress::{MultiProgress, Progress},
@@ -189,8 +190,15 @@ pub async fn ensure_busted(
     let busted_req = PackageReq::new("busted".into(), None)?;
 
     if !tree.match_rocks(&busted_req)?.is_found() {
+        let install_spec = PackageInstallSpec::new(
+            busted_req,
+            BuildBehaviour::default(),
+            PinnedState::default(),
+            OptState::default(),
+            true,
+        );
         Install::new(tree, config)
-            .package(busted_req.into())
+            .package(install_spec)
             .progress(progress)
             .install()
             .await?;
@@ -229,6 +237,7 @@ async fn ensure_dependencies(
                     build_behaviour,
                     *dep.pin(),
                     *dep.opt(),
+                    true,
                 )
             })
         });
@@ -259,6 +268,7 @@ async fn ensure_dependencies(
                     build_behaviour,
                     *dep.pin(),
                     *dep.opt(),
+                    true,
                 )
             })
         });

--- a/lux-lib/src/operations/update.rs
+++ b/lux-lib/src/operations/update.rs
@@ -5,6 +5,7 @@ use itertools::Itertools;
 use thiserror::Error;
 
 use crate::{
+    build::BuildBehaviour,
     config::{Config, LuaVersion, LuaVersionUnset},
     lockfile::{
         LocalPackage, LocalPackageLockType, Lockfile, PinnedState, ProjectLockfile, ReadOnly,
@@ -19,7 +20,7 @@ use crate::{
     tree::Tree,
 };
 
-use super::{Install, InstallError, Remove, RemoveError, SyncError};
+use super::{Install, InstallError, PackageInstallSpec, Remove, RemoveError, SyncError};
 
 #[derive(Error, Debug)]
 pub enum UpdateError {
@@ -215,7 +216,8 @@ async fn update_dependency_tree(
         .into_iter()
         .filter(|pkg| is_included(pkg, packages))
         .collect_vec();
-    let updated_dependencies = update(dependencies, package_db, tree, config, progress).await?;
+    let updated_dependencies =
+        update(dependencies, package_db, tree, &lockfile, config, progress).await?;
     if !updated_dependencies.is_empty() {
         let updated_lockfile = tree.lockfile()?;
         project_lockfile.sync(updated_lockfile.local_pkg_lock(), &lock_type);
@@ -245,13 +247,22 @@ async fn update_install_tree(
         .into_iter()
         .filter(|pkg| is_included(pkg, &args.packages))
         .collect_vec();
-    update(packages, package_db, &tree, args.config, args.progress).await
+    update(
+        packages,
+        package_db,
+        &tree,
+        &lockfile,
+        args.config,
+        args.progress,
+    )
+    .await
 }
 
 async fn update(
     packages: Vec<(LocalPackage, PackageReq)>,
     package_db: RemotePackageDB,
     tree: &Tree,
+    lockfile: &Lockfile<ReadOnly>,
     config: &Config,
     progress: Arc<Progress<MultiProgress>>,
 ) -> Result<Vec<LocalPackage>, UpdateError> {
@@ -263,7 +274,9 @@ async fn update(
                 .to_package()
                 .has_update_with(&constraint, &package_db)
             {
-                Ok(Some(_)) if package.pinned() == PinnedState::Unpinned => Some(constraint),
+                Ok(Some(_)) if package.pinned() == PinnedState::Unpinned => {
+                    Some((package, constraint))
+                }
                 _ => None,
             }
         })
@@ -271,16 +284,20 @@ async fn update(
     if updatable.is_empty() {
         Ok(Vec::new())
     } else {
-        let updated_packages = Install::new(tree, config)
-            .packages(updatable.iter().map(|constraint| constraint.clone().into()))
-            .package_db(package_db)
-            .progress(progress.clone())
-            .install()
-            .await?;
         Remove::new(config)
-            .packages(packages.into_iter().map(|package| package.0.id()))
-            .progress(progress)
+            .packages(updatable.iter().map(|(package, _)| package.id()))
+            .progress(progress.clone())
             .remove()
+            .await?;
+        let updated_packages = Install::new(tree, config)
+            .packages(
+                updatable
+                    .iter()
+                    .map(|updatable| mk_install_spec(updatable, lockfile)),
+            )
+            .package_db(package_db)
+            .progress(progress)
+            .install()
             .await?;
         Ok(updated_packages)
     }
@@ -293,4 +310,18 @@ fn unpinned_packages(lockfile: &Lockfile<ReadOnly>) -> Vec<(LocalPackage, Packag
         .filter(|package| package.pinned() == PinnedState::Unpinned)
         .map(|package| (package.clone(), package.to_package().into_package_req()))
         .collect_vec()
+}
+
+fn mk_install_spec(
+    (package, req): &(LocalPackage, PackageReq),
+    lockfile: &Lockfile<ReadOnly>,
+) -> PackageInstallSpec {
+    let is_entrypoint = lockfile.is_entrypoint(&package.id());
+    PackageInstallSpec::new(
+        req.clone(),
+        BuildBehaviour::default(),
+        PinnedState::Unpinned,
+        package.opt().clone(),
+        is_entrypoint,
+    )
 }

--- a/lux-lib/src/operations/update.rs
+++ b/lux-lib/src/operations/update.rs
@@ -321,7 +321,7 @@ fn mk_install_spec(
         req.clone(),
         BuildBehaviour::default(),
         PinnedState::Unpinned,
-        package.opt().clone(),
+        package.opt(),
         is_entrypoint,
     )
 }

--- a/lux-lib/src/operations/update.rs
+++ b/lux-lib/src/operations/update.rs
@@ -17,7 +17,7 @@ use crate::{
     project::{Project, ProjectError, ProjectTreeError},
     remote_package_db::{RemotePackageDB, RemotePackageDBError},
     rockspec::Rockspec,
-    tree::Tree,
+    tree::{self, Tree},
 };
 
 use super::{Install, InstallError, PackageInstallSpec, Remove, RemoveError, SyncError};
@@ -316,12 +316,16 @@ fn mk_install_spec(
     (package, req): &(LocalPackage, PackageReq),
     lockfile: &Lockfile<ReadOnly>,
 ) -> PackageInstallSpec {
-    let is_entrypoint = lockfile.is_entrypoint(&package.id());
+    let entry_type = if lockfile.is_entrypoint(&package.id()) {
+        tree::EntryType::Entrypoint
+    } else {
+        tree::EntryType::DependencyOnly
+    };
     PackageInstallSpec::new(
         req.clone(),
         BuildBehaviour::default(),
         PinnedState::Unpinned,
         package.opt(),
-        is_entrypoint,
+        entry_type,
     )
 }

--- a/lux-lib/src/package/mod.rs
+++ b/lux-lib/src/package/mod.rs
@@ -409,6 +409,21 @@ impl Display for PackageName {
     }
 }
 
+#[derive(Debug)]
+pub struct PackageNameList(Vec<PackageName>);
+
+impl PackageNameList {
+    pub(crate) fn new(package_names: Vec<PackageName>) -> Self {
+        Self(package_names)
+    }
+}
+
+impl Display for PackageNameList {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.0.iter().map(|pkg| pkg.to_string()).join(", ").as_str())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/lux-lib/src/path.rs
+++ b/lux-lib/src/path.rs
@@ -43,7 +43,8 @@ impl Paths {
                     .map(|package| tree.rock_layout(&package))
                     .collect_vec()
             })
-            .fold(Self::default(&tree), |mut paths, package| {
+            .try_fold(Self::default(&tree), |mut paths, package| {
+                let package = package?;
                 paths.src.0.push(package.src.join("?.lua"));
                 paths.src.0.push(package.src.join("?").join("init.lua"));
                 paths
@@ -51,8 +52,8 @@ impl Paths {
                     .0
                     .push(package.lib.join(format!("?.{}", lua_lib_extension())));
                 paths.bin.0.push(package.bin);
-                paths
-            });
+                Ok::<Paths, io::Error>(paths)
+            })?;
 
         let lib_path = option_env!("LUX_LIB_DIR")
             .map(PathBuf::from)

--- a/lux-lib/src/path.rs
+++ b/lux-lib/src/path.rs
@@ -40,7 +40,7 @@ impl Paths {
             .flat_map(|(_, packages)| {
                 packages
                     .into_iter()
-                    .map(|package| tree.rock_layout(&package))
+                    .map(|package| tree.installed_rock_layout(&package))
                     .collect_vec()
             })
             .try_fold(Self::default(&tree), |mut paths, package| {

--- a/lux-lib/src/project/mod.rs
+++ b/lux-lib/src/project/mod.rs
@@ -193,7 +193,7 @@ impl Project {
     pub fn try_lockfile(&self) -> Result<Option<ProjectLockfile<ReadOnly>>, io::Error> {
         let path = self.lockfile_path();
         if path.is_file() {
-            Ok(Some(ProjectLockfile::new(path)?))
+            Ok(Some(ProjectLockfile::load(path)?))
         } else {
             Ok(None)
         }
@@ -234,9 +234,7 @@ impl Project {
     }
 
     pub fn test_tree(&self, config: &Config) -> Result<Tree, ProjectTreeError> {
-        let tree = self.tree(config)?;
-        let test_tree_root = tree.root().join("test_dependencies");
-        Ok(Tree::new(test_tree_root, self.lua_version(config)?)?)
+        Ok(config.test_tree(self.lua_version(config)?)?)
     }
 
     pub fn lua_version(&self, config: &Config) -> Result<LuaVersion, LuaVersionError> {

--- a/lux-lib/src/tree/mod.rs
+++ b/lux-lib/src/tree/mod.rs
@@ -299,6 +299,12 @@ impl mlua::UserData for Tree {
     }
 }
 
+#[derive(Copy, Debug, PartialEq, Eq, Hash, Clone, PartialOrd, Ord)]
+pub enum EntryType {
+    Entrypoint,
+    DependencyOnly,
+}
+
 #[derive(Clone, Debug)]
 pub enum RockMatches {
     NotFound(PackageReq),

--- a/lux-lib/src/tree/mod.rs
+++ b/lux-lib/src/tree/mod.rs
@@ -207,7 +207,7 @@ impl Tree {
             OptState::Required => etc_root.join(&layout_config.etc),
             OptState::Optional => etc_root.join(&layout_config.opt_etc),
         };
-        if let Some(_) = layout_config.etc_root {
+        if layout_config.etc_root.is_some() {
             etc = etc.join(format!("{}", package.name()));
         }
         let lib = rock_path.join("lib");

--- a/lux-lib/src/which/mod.rs
+++ b/lux-lib/src/which/mod.rs
@@ -81,7 +81,7 @@ fn do_search(which: Which<'_>) -> Result<PathBuf, WhichError> {
     local_packages
         .into_iter()
         .filter_map(|pkg| {
-            let rock_layout = tree.rock_layout(&pkg);
+            let rock_layout = tree.rock_layout(&pkg).ok()?;
             let lib_path = rock_layout.lib.join(which.module.to_lib_path());
             if lib_path.is_file() {
                 return Some(lib_path);

--- a/lux-lib/src/which/mod.rs
+++ b/lux-lib/src/which/mod.rs
@@ -81,7 +81,7 @@ fn do_search(which: Which<'_>) -> Result<PathBuf, WhichError> {
     local_packages
         .into_iter()
         .filter_map(|pkg| {
-            let rock_layout = tree.rock_layout(&pkg).ok()?;
+            let rock_layout = tree.installed_rock_layout(&pkg).ok()?;
             let lib_path = rock_layout.lib.join(which.module.to_lib_path());
             if lib_path.is_file() {
                 return Some(lib_path);

--- a/lux-lib/tests/build.rs
+++ b/lux-lib/tests/build.rs
@@ -5,6 +5,7 @@ use lux_lib::{
     config::{ConfigBuilder, LuaVersion},
     lua_rockspec::RemoteLuaRockspec,
     progress::{MultiProgress, Progress},
+    tree,
 };
 use tempdir::TempDir;
 
@@ -28,11 +29,17 @@ async fn builtin_build() {
 
     let tree = config.tree(LuaVersion::from(&config).unwrap()).unwrap();
 
-    Build::new(&rockspec, &tree, true, &config, &Progress::Progress(bar))
-        .behaviour(Force)
-        .build()
-        .await
-        .unwrap();
+    Build::new(
+        &rockspec,
+        &tree,
+        tree::EntryType::Entrypoint,
+        &config,
+        &Progress::Progress(bar),
+    )
+    .behaviour(Force)
+    .build()
+    .await
+    .unwrap();
 }
 
 #[tokio::test]
@@ -56,11 +63,17 @@ async fn make_build() {
 
     let tree = config.tree(LuaVersion::from(&config).unwrap()).unwrap();
 
-    Build::new(&rockspec, &tree, true, &config, &Progress::Progress(bar))
-        .behaviour(Force)
-        .build()
-        .await
-        .unwrap();
+    Build::new(
+        &rockspec,
+        &tree,
+        tree::EntryType::Entrypoint,
+        &config,
+        &Progress::Progress(bar),
+    )
+    .behaviour(Force)
+    .build()
+    .await
+    .unwrap();
 }
 
 #[tokio::test]
@@ -96,11 +109,17 @@ async fn test_build_rockspec(rockspec_path: PathBuf) {
 
     let tree = config.tree(LuaVersion::from(&config).unwrap()).unwrap();
 
-    Build::new(&rockspec, &tree, true, &config, &Progress::Progress(bar))
-        .behaviour(Force)
-        .build()
-        .await
-        .unwrap();
+    Build::new(
+        &rockspec,
+        &tree,
+        tree::EntryType::Entrypoint,
+        &config,
+        &Progress::Progress(bar),
+    )
+    .behaviour(Force)
+    .build()
+    .await
+    .unwrap();
 }
 
 #[tokio::test]
@@ -124,9 +143,15 @@ async fn treesitter_parser_build() {
 
     let tree = config.tree(LuaVersion::from(&config).unwrap()).unwrap();
 
-    Build::new(&rockspec, &tree, true, &config, &Progress::Progress(bar))
-        .behaviour(Force)
-        .build()
-        .await
-        .unwrap();
+    Build::new(
+        &rockspec,
+        &tree,
+        tree::EntryType::Entrypoint,
+        &config,
+        &Progress::Progress(bar),
+    )
+    .behaviour(Force)
+    .build()
+    .await
+    .unwrap();
 }

--- a/lux-lib/tests/build.rs
+++ b/lux-lib/tests/build.rs
@@ -28,7 +28,7 @@ async fn builtin_build() {
 
     let tree = config.tree(LuaVersion::from(&config).unwrap()).unwrap();
 
-    Build::new(&rockspec, &tree, &config, &Progress::Progress(bar))
+    Build::new(&rockspec, &tree, true, &config, &Progress::Progress(bar))
         .behaviour(Force)
         .build()
         .await
@@ -56,7 +56,7 @@ async fn make_build() {
 
     let tree = config.tree(LuaVersion::from(&config).unwrap()).unwrap();
 
-    Build::new(&rockspec, &tree, &config, &Progress::Progress(bar))
+    Build::new(&rockspec, &tree, true, &config, &Progress::Progress(bar))
         .behaviour(Force)
         .build()
         .await
@@ -96,7 +96,7 @@ async fn test_build_rockspec(rockspec_path: PathBuf) {
 
     let tree = config.tree(LuaVersion::from(&config).unwrap()).unwrap();
 
-    Build::new(&rockspec, &tree, &config, &Progress::Progress(bar))
+    Build::new(&rockspec, &tree, true, &config, &Progress::Progress(bar))
         .behaviour(Force)
         .build()
         .await
@@ -124,7 +124,7 @@ async fn treesitter_parser_build() {
 
     let tree = config.tree(LuaVersion::from(&config).unwrap()).unwrap();
 
-    Build::new(&rockspec, &tree, &config, &Progress::Progress(bar))
+    Build::new(&rockspec, &tree, true, &config, &Progress::Progress(bar))
         .behaviour(Force)
         .build()
         .await

--- a/lux-lib/tests/tree.rs
+++ b/lux-lib/tests/tree.rs
@@ -1,7 +1,4 @@
-use lux_lib::{
-    config::{ConfigBuilder, LuaVersion},
-    tree::Tree,
-};
+use lux_lib::config::{ConfigBuilder, LuaVersion};
 use mlua::{IntoLua, Lua};
 use tempdir::TempDir;
 

--- a/lux-lib/tests/tree.rs
+++ b/lux-lib/tests/tree.rs
@@ -1,4 +1,7 @@
-use lux_lib::tree::Tree;
+use lux_lib::{
+    config::{ConfigBuilder, LuaVersion},
+    tree::Tree,
+};
 use mlua::{IntoLua, Lua};
 use tempdir::TempDir;
 
@@ -7,7 +10,12 @@ fn tree_userdata() {
     let temp = TempDir::new("tree-userdata").unwrap();
 
     let lua = Lua::new();
-    let t = Tree::new(temp.into_path(), lux_lib::config::LuaVersion::Lua51).unwrap();
+    let config = ConfigBuilder::new()
+        .unwrap()
+        .tree(Some(temp.into_path()))
+        .build()
+        .unwrap();
+    let t = config.tree(LuaVersion::Lua51).unwrap();
     let tree = t.into_lua(&lua).unwrap();
     lua.globals().set("tree", tree).unwrap();
 

--- a/lux-lua/src/loader.rs
+++ b/lux-lua/src/loader.rs
@@ -92,7 +92,7 @@ pub fn loader(lua: &Lua, module: String) -> mlua::Result<Option<mlua::Function>>
         .find(|path| path.file_name().is_some_and(|filename| filename == ".lux"))
     {
         // Get the name of the current module, so we can look up its dependencies in the lockfile.
-        let lockfile = Lockfile::new(lock_path.join("lux.lock")).into_lua_err()?;
+        let lockfile = Lockfile::load(lock_path.join("lux.lock")).into_lua_err()?;
 
         // If we're in a lux tree, the path looks like `.lux/5.4/12345678-package_name-1.0.0/src/code.lua`
         // we need to extract the hash from the path.

--- a/lux-workspace-hack/Cargo.toml
+++ b/lux-workspace-hack/Cargo.toml
@@ -26,6 +26,7 @@ futures-channel = { version = "0.3", features = ["sink"] }
 futures-core = { version = "0.3" }
 futures-sink = { version = "0.3" }
 futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
+getrandom = { version = "0.2", default-features = false, features = ["std"] }
 hyper = { version = "1", features = ["client", "http1", "http2", "server"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "http1", "http2", "server"] }
 indexmap = { version = "1", default-features = false, features = ["std"] }


### PR DESCRIPTION
This is a draft for allowing us to configure the install tree so that it can be made compatible with Neovim's `packpath` without any symlink hacks on the rocks.nvim side.

I'd like to make this generic, so that we can potentially serve other use cases in the future.

Also fixes #463.