### PR TITLE
fix(`lx new`): don't search parents for existing project

### DIFF
--- a/lux-cli/src/project/new.rs
+++ b/lux-cli/src/project/new.rs
@@ -103,7 +103,7 @@ fn validate_license(input: &str) -> std::result::Result<Validation, Box<dyn Erro
 }
 
 pub async fn write_project_rockspec(cli_flags: NewProject) -> Result<()> {
-    let project = Project::from(cli_flags.directory.clone())?;
+    let project = Project::from_exact(cli_flags.directory.clone())?;
     let render_config = RenderConfig::default_colored()
         .with_prompt_prefix(Styled::new(">").with_fg(inquire::ui::Color::LightGreen));
 


### PR DESCRIPTION
Used to prevent unnecessary warnings when creating a project within a subdirectory of an existing project.