### PR TITLE
feat: implicitly propagate environment variables to subprocesses

### DIFF
--- a/lux-cli/src/exec.rs
+++ b/lux-cli/src/exec.rs
@@ -28,7 +28,7 @@ pub async fn exec(run: Exec, config: Config) -> Result<()> {
         None => LuaVersion::from(&config)?,
     };
     let tree = config.tree(lua_version)?;
-    let paths = Paths::new(tree)?;
+    let paths = Paths::new(&tree)?;
     unsafe {
         // safe as long as this is single-threaded
         env::set_var("PATH", paths.path_prepended().joined());

--- a/lux-cli/src/path.rs
+++ b/lux-cli/src/path.rs
@@ -81,7 +81,7 @@ impl Default for Shell {
 
 pub async fn path(path_data: Path, config: Config) -> Result<()> {
     let tree = config.tree(LuaVersion::from(&config)?)?;
-    let paths = Paths::new(tree)?;
+    let paths = Paths::new(&tree)?;
     let cmd = path_data.cmd.unwrap_or_default();
     let prepend = path_data.prepend;
     match cmd {

--- a/lux-lib/src/luarocks/luarocks_installation.rs
+++ b/lux-lib/src/luarocks/luarocks_installation.rs
@@ -263,7 +263,7 @@ impl LuaRocksInstallation {
         cwd: &Path,
         lua: &LuaInstallation,
     ) -> Result<(), ExecLuaRocksError> {
-        let luarocks_paths = Paths::new(self.tree)?;
+        let luarocks_paths = Paths::new(&self.tree)?;
         // Ensure a pure environment so we can do parallel builds
         let temp_dir = TempDir::new("lux-run-luarocks").unwrap();
         let luarocks_config_content = format!(

--- a/lux-lib/src/operations/exec.rs
+++ b/lux-lib/src/operations/exec.rs
@@ -77,10 +77,10 @@ async fn exec(run: Exec<'_>) -> Result<(), ExecError> {
         .unwrap_or(LuaVersion::from(run.config)?);
 
     let user_tree = run.config.tree(lua_version)?;
-    let mut paths = Paths::new(user_tree)?;
+    let mut paths = Paths::new(&user_tree)?;
 
     if let Some(project) = run.project {
-        paths.prepend(&Paths::new(project.tree(run.config)?)?);
+        paths.prepend(&Paths::new(&project.tree(run.config)?)?);
     }
 
     let status = match Command::new(run.command)

--- a/lux-lib/src/operations/run.rs
+++ b/lux-lib/src/operations/run.rs
@@ -79,6 +79,7 @@ async fn run_with_local_lua(
 
     operations::run_lua(
         project.root(),
+        &project.tree(config)?,
         version,
         LuaBinary::Lua,
         &args.into_iter().cloned().collect(),
@@ -95,7 +96,7 @@ async fn run_with_command(
     config: &Config,
 ) -> Result<(), RunError> {
     let tree = project.tree(config)?;
-    let paths = Paths::new(tree)?;
+    let paths = Paths::new(&tree)?;
 
     match Command::new(command.deref())
         .args(args.into_iter().cloned().collect_vec())

--- a/lux-lib/src/operations/test.rs
+++ b/lux-lib/src/operations/test.rs
@@ -133,8 +133,8 @@ async fn run_tests(test: Test<'_>) -> Result<(), RunTestsError> {
             .await?;
     }
     let test_tree_root = &test_tree.root().clone();
-    let mut paths = Paths::new(project_tree)?;
-    let test_tree_paths = Paths::new(test_tree)?;
+    let mut paths = Paths::new(&project_tree)?;
+    let test_tree_paths = Paths::new(&test_tree)?;
     paths.prepend(&test_tree_paths);
     let mut command = Command::new("busted");
     let mut command = command

--- a/lux-lib/src/path.rs
+++ b/lux-lib/src/path.rs
@@ -33,7 +33,7 @@ impl Paths {
         }
     }
 
-    pub fn new(tree: Tree) -> io::Result<Self> {
+    pub fn new(tree: &Tree) -> io::Result<Self> {
         let mut paths = tree
             .list()?
             .into_iter()
@@ -43,7 +43,7 @@ impl Paths {
                     .map(|package| tree.installed_rock_layout(&package))
                     .collect_vec()
             })
-            .try_fold(Self::default(&tree), |mut paths, package| {
+            .try_fold(Self::default(tree), |mut paths, package| {
                 let package = package?;
                 paths.src.0.push(package.src.join("?.lua"));
                 paths.src.0.push(package.src.join("?").join("init.lua"));


### PR DESCRIPTION
closes #510 and improves user experience by no longer requiring them to `eval $(lx path ...)` all the time.