### PR TITLE
feat(debug project): flag to list included files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2176,6 +2176,7 @@ dependencies = [
  "octocrab",
  "open",
  "path-absolutize",
+ "pathdiff",
  "serde_json",
  "serial_test",
  "spdx",
@@ -2185,6 +2186,7 @@ dependencies = [
  "stylua",
  "tempdir",
  "termcolor",
+ "termtree 0.5.1",
  "text_trees",
  "tokio",
  "toml",
@@ -2823,9 +2825,9 @@ checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
 
 [[package]]
 name = "pathdiff"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c5ce1153ab5b689d0c074c4e7fc613e942dfb7dd9eea5ab202d2ad91fe361"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pbkdf2"
@@ -2984,7 +2986,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13"
 dependencies = [
  "predicates-core",
- "termtree",
+ "termtree 0.4.1",
 ]
 
 [[package]]
@@ -4110,6 +4112,12 @@ name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "text_trees"

--- a/lux-cli/Cargo.toml
+++ b/lux-cli/Cargo.toml
@@ -45,6 +45,8 @@ url = "2.5.4"
 open = "5.3.2"
 edit = "0.1.5"
 lux-workspace-hack = { version = "0.1", path = "../lux-workspace-hack" }
+pathdiff = "0.2.3"
+termtree = "0.5.1"
 
 [dev-dependencies]
 serial_test = { version = "3.2.0" }

--- a/lux-cli/src/bin/lx.rs
+++ b/lux-cli/src/bin/lx.rs
@@ -55,7 +55,7 @@ async fn main() {
             Debug::UnpackRemote(unpack_data) => {
                 unpack::unpack_remote(unpack_data, config).await.unwrap()
             }
-            Debug::Project => project::debug_project().unwrap(),
+            Debug::Project(debug_project) => project::debug_project(debug_project).unwrap(),
         },
         Commands::New(project_data) => project::write_project_rockspec(project_data).await.unwrap(),
         Commands::Build(build_data) => build::build(build_data, config).await.unwrap(),

--- a/lux-cli/src/debug.rs
+++ b/lux-cli/src/debug.rs
@@ -1,4 +1,7 @@
-use crate::unpack::{Unpack, UnpackRemote};
+use crate::{
+    project::DebugProject,
+    unpack::{Unpack, UnpackRemote},
+};
 use clap::Subcommand;
 
 #[derive(Subcommand)]
@@ -10,5 +13,5 @@ pub enum Debug {
     /// Download a .src.rock from luarocks.org and unpack it.
     UnpackRemote(UnpackRemote),
     /// View information about the current project.
-    Project,
+    Project(DebugProject),
 }

--- a/lux-cli/src/project/debug.rs
+++ b/lux-cli/src/project/debug.rs
@@ -1,7 +1,20 @@
+use clap::Args;
 use eyre::Result;
 use lux_lib::project::Project;
 
-pub fn debug_project() -> Result<()> {
+use crate::utils::file_tree::term_tree_from_paths;
+
+#[derive(Args)]
+pub struct DebugProject {
+    /// List files that are included.
+    /// To avoid copying large files that are not relevant to the build process,
+    /// Lux excludes hidden files and files that are ignored
+    /// (e.g. by .gitignore or other .ignore files).
+    #[arg(long)]
+    list_files: bool,
+}
+
+pub fn debug_project(args: DebugProject) -> Result<()> {
     let project = Project::current()?;
 
     if let Some(project) = project {
@@ -11,6 +24,16 @@ pub fn debug_project() -> Result<()> {
         println!("Project version: {}", rocks.version());
 
         println!("Project location: {}", project.root().display());
+
+        if args.list_files {
+            let project_files = project.project_files();
+            if project_files.is_empty() {
+                println!("\nNo included project files detected.");
+            } else {
+                let project_tree = term_tree_from_paths(&project_files);
+                println!("\nIncluded project files:\n\n{}.", project_tree);
+            }
+        }
     } else {
         eprintln!("Could not find project in current directory.");
     }

--- a/lux-cli/src/utils/file_tree.rs
+++ b/lux-cli/src/utils/file_tree.rs
@@ -1,0 +1,224 @@
+use itertools::Itertools;
+use pathdiff::diff_paths;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use termtree::Tree;
+
+pub(crate) fn term_tree_from_paths(paths: &[PathBuf]) -> Tree<String> {
+    let root_dir = find_common_root(paths).unwrap_or_else(|| PathBuf::from("."));
+
+    let mut path_children: HashMap<PathBuf, Vec<(PathBuf, String)>> = HashMap::new();
+
+    let sorted_paths = paths
+        .iter()
+        .sorted_by_key(|p| p.components().count())
+        .collect::<Vec<_>>();
+
+    for path in sorted_paths {
+        let rel_path = diff_paths(path, &root_dir).unwrap_or_else(|| path.clone());
+
+        let mut component_path = root_dir.clone();
+        let mut components_with_paths = Vec::new();
+
+        for component in rel_path.components() {
+            component_path = component_path.join(component);
+            let name = component.as_os_str().to_string_lossy().to_string();
+            components_with_paths.push((component_path.clone(), name));
+        }
+
+        if !components_with_paths.is_empty() {
+            path_children
+                .entry(root_dir.clone())
+                .or_default()
+                .push(components_with_paths[0].clone());
+
+            for pair in components_with_paths.windows(2) {
+                let (parent_path, _) = &pair[0];
+                path_children
+                    .entry(parent_path.clone())
+                    .or_default()
+                    .push(pair[1].clone());
+            }
+        }
+    }
+
+    for children in path_children.values_mut() {
+        children.sort_by(|a, b| a.1.cmp(&b.1));
+        children.dedup_by(|a, b| a.0 == b.0);
+    }
+
+    let root_name = root_dir.file_name().map_or_else(
+        || root_dir.to_string_lossy().to_string(),
+        |name| name.to_string_lossy().to_string(),
+    );
+
+    build_tree_node(root_dir, root_name, &path_children)
+}
+
+fn build_tree_node(
+    path: PathBuf,
+    name: String,
+    path_children: &HashMap<PathBuf, Vec<(PathBuf, String)>>,
+) -> Tree<String> {
+    let mut node = Tree::new(name);
+    if let Some(children) = path_children.get(&path) {
+        for (child_path, child_name) in children {
+            let child_node = build_tree_node(child_path.clone(), child_name.clone(), path_children);
+            node.push(child_node);
+        }
+    }
+    node
+}
+
+fn find_common_root(paths: &[PathBuf]) -> Option<PathBuf> {
+    if paths.is_empty() {
+        return None;
+    }
+    if paths.len() == 1 {
+        return Some(PathBuf::from("."));
+    }
+    let get_parent = |path: &PathBuf| -> PathBuf {
+        path.parent()
+            .map_or_else(|| PathBuf::from("."), Path::to_path_buf)
+    };
+    let first_parent = get_parent(&paths[0]);
+
+    let common_prefix = |a: &Path, b: &Path| -> Option<PathBuf> {
+        let a_components = a.components().collect::<Vec<_>>();
+        let b_components = b.components().collect::<Vec<_>>();
+        let common = a_components
+            .iter()
+            .zip(b_components.iter())
+            .take_while(|(x, y)| x == y)
+            .map(|(x, _)| *x)
+            .collect::<Vec<_>>();
+        if common.is_empty() {
+            None
+        } else {
+            Some(common.into_iter().collect())
+        }
+    };
+
+    paths
+        .iter()
+        .skip(1)
+        .map(get_parent)
+        .try_fold(first_parent, |acc, path| common_prefix(&acc, &path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_simple_tree_structure() {
+        let paths: Vec<PathBuf> = vec![
+            PathBuf::from("src/main.lua"),
+            PathBuf::from("src/lib.lua"),
+            PathBuf::from("src/utils/helpers.lua"),
+            PathBuf::from("src/utils/config.lua"),
+            PathBuf::from("tests/integration.lua"),
+            PathBuf::from("README.md"),
+        ];
+
+        let tree = term_tree_from_paths(&paths);
+        let tree_string = tree.to_string();
+
+        assert!(tree_string.contains("─ src"));
+        assert!(tree_string.contains("─ tests"));
+        assert!(tree_string.contains("─ utils"));
+        assert!(tree_string.contains("─ main.lua"));
+        assert!(tree_string.contains("─ lib.lua"));
+        assert!(tree_string.contains("─ helpers.lua"));
+        assert!(tree_string.contains("─ config.lua"));
+        assert!(tree_string.contains("─ integration.lua"));
+        assert!(tree_string.contains("─ README.md"));
+    }
+
+    #[test]
+    fn test_empty_paths() {
+        let paths: Vec<PathBuf> = vec![];
+        let tree = term_tree_from_paths(&paths);
+        assert_eq!(tree.to_string(), ".\n");
+    }
+
+    #[test]
+    fn test_single_file() {
+        let paths: Vec<PathBuf> = vec![PathBuf::from("file.txt")];
+        let tree = term_tree_from_paths(&paths);
+        assert!(tree.to_string().contains("file.txt"));
+    }
+
+    #[test]
+    fn test_nested_single_path() {
+        let paths: Vec<PathBuf> = vec![PathBuf::from("a/b/c/d/file.txt")];
+        let tree = term_tree_from_paths(&paths);
+        let tree_string = dbg!(tree.to_string());
+
+        assert!(tree_string.contains("a"));
+        assert!(tree_string.contains("b"));
+        assert!(tree_string.contains("c"));
+        assert!(tree_string.contains("d"));
+        assert!(tree_string.contains("file.txt"));
+    }
+
+    #[test]
+    fn test_find_common_root() {
+        let paths = vec![
+            PathBuf::from("/home/user/project/src/main.rs"),
+            PathBuf::from("/home/user/project/src/lib.rs"),
+            PathBuf::from("/home/user/project/tests/test.rs"),
+        ];
+
+        let common_root = find_common_root(&paths);
+        assert!(common_root.is_some());
+        assert_eq!(common_root.unwrap(), PathBuf::from("/home/user/project"));
+    }
+
+    #[test]
+    fn test_no_common_root() {
+        let paths = vec![
+            PathBuf::from("/home/user1/file.txt"),
+            PathBuf::from("/home/user2/file.txt"),
+        ];
+
+        let common_root = find_common_root(&paths);
+        assert!(common_root.is_some());
+        assert_eq!(common_root.unwrap(), PathBuf::from("/home"));
+    }
+
+    #[test]
+    fn test_duplicate_paths() {
+        let paths: Vec<PathBuf> = vec![
+            PathBuf::from("src/file.txt"),
+            PathBuf::from("src/file.txt"),
+            PathBuf::from("src/other.txt"),
+        ];
+
+        let tree = term_tree_from_paths(&paths);
+        let tree_string = tree.to_string();
+
+        assert_eq!(
+            tree_string.matches("file.txt").count(),
+            1,
+            "Duplicate paths should be deduplicated"
+        );
+    }
+
+    #[test]
+    fn test_maintain_depth() {
+        let paths: Vec<PathBuf> = vec![
+            PathBuf::from("a/b/c/deep.txt"),
+            PathBuf::from("a/shallow.txt"),
+        ];
+
+        let tree = term_tree_from_paths(&paths);
+        let tree_string = dbg!(tree.to_string());
+
+        assert!(tree_string.contains("deep.txt"));
+        assert!(tree_string.contains("shallow.txt"));
+        assert!(tree_string.contains("a"));
+        assert!(tree_string.contains("b"));
+        assert!(tree_string.contains("c"));
+    }
+}

--- a/lux-cli/src/utils/mod.rs
+++ b/lux-cli/src/utils/mod.rs
@@ -1,2 +1,3 @@
-pub mod github_metadata;
-pub mod install;
+pub(crate) mod file_tree;
+pub(crate) mod github_metadata;
+pub(crate) mod install;

--- a/lux-lib/src/build/utils.rs
+++ b/lux-lib/src/build/utils.rs
@@ -32,25 +32,30 @@ pub(crate) fn copy_lua_to_module_path(
     Ok(())
 }
 
+/// Get the files that Lux treats as project files
+/// This respects ignore files and excludes hidden files and directories.
+pub(crate) fn project_files(src: &PathBuf) -> Vec<PathBuf> {
+    ignore::WalkBuilder::new(src)
+        .follow_links(false)
+        .build()
+        .filter_map(Result::ok)
+        .filter(|entry| entry.file_type().is_some_and(|ft| ft.is_file()))
+        .map(|entry| entry.into_path())
+        .collect_vec()
+}
+
 /// Recursively copy a directory.
 /// This respects ignore files and excludes hidden files and directories.
 pub(crate) fn recursive_copy_dir(src: &PathBuf, dest: &Path) -> Result<(), io::Error> {
     if src.exists() {
-        for file in ignore::WalkBuilder::new(src)
-            .follow_links(false)
-            .build()
-            .filter_map(Result::ok)
-            .filter(|entry| entry.file_type().is_some_and(|ft| ft.is_file()))
-        {
+        for file in project_files(src) {
             let relative_src_path: PathBuf =
-                pathdiff::diff_paths(src.join(file.clone().into_path()), src)
-                    .expect("failed to copy directories!");
-            let filepath = file.path();
+                pathdiff::diff_paths(src.join(&file), src).expect("failed to copy directories!");
             let target = dest.join(relative_src_path);
             if let Some(parent) = target.parent() {
                 std::fs::create_dir_all(parent)?;
             }
-            std::fs::copy(filepath, target)?;
+            std::fs::copy(&file, target)?;
         }
     }
     Ok(())

--- a/lux-lib/src/project/mod.rs
+++ b/lux-lib/src/project/mod.rs
@@ -14,6 +14,7 @@ use thiserror::Error;
 use toml_edit::{DocumentMut, Item};
 
 use crate::{
+    build,
     config::{Config, LuaVersion},
     lockfile::{ProjectLockfile, ReadOnly},
     lua_rockspec::{
@@ -626,6 +627,10 @@ impl Project {
         tokio::fs::write(self.toml_path(), project_toml.to_string()).await?;
 
         Ok(())
+    }
+
+    pub fn project_files(&self) -> Vec<PathBuf> {
+        build::utils::project_files(&self.root().0)
     }
 }
 


### PR DESCRIPTION
Can be run with

```
❯ : lx debug project --list-files
Project name: lux-t2
Project version: 0.1.0-1
Project location: /tmp/lux-t2

Included project files:

lux-t2
├── lux.lock
├── lux.toml
└── src
    ├── main.lua
    └── repl.lua
.


```