### PR TITLE
fix(release-plz): use a simpler release name for `lux-cli`

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -4,7 +4,6 @@ changelog_path = "./CHANGELOG.md"
 
 [changelog]
 body = """
-
 ## `{{ package }}` - [{{ version | trim_start_matches(pat="v") }}]{%- if release_link -%}({{ release_link }}){% endif %} - {{ timestamp | date(format="%Y-%m-%d") }}
 {% for group, commits in commits | group_by(attribute="group") %}
 ### {{ group | upper_first }}
@@ -21,6 +20,7 @@ body = """
 [[package]]
 name = "lux-cli"
 git_tag_name = "v{{ version }}"
+git_release_name = "v{{ version }}"
 
 [[package]]
 name = "lux-workspace-hack"


### PR DESCRIPTION
This should finally fix `cargo binstall` not working with `lux-cli` :)