### PR TITLE
fix(release-plz): don't use relative path for changelog

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,9 +1,10 @@
 [workspace]
 # set the path of all the crates to the changelog to the root of the repository
-changelog_path = "./CHANGELOG.md"
+changelog_path = "CHANGELOG.md"
 
 [changelog]
 body = """
+
 ## `{{ package }}` - [{{ version | trim_start_matches(pat="v") }}]{%- if release_link -%}({{ release_link }}){% endif %} - {{ timestamp | date(format="%Y-%m-%d") }}
 {% for group, commits in commits | group_by(attribute="group") %}
 ### {{ group | upper_first }}


### PR DESCRIPTION
I hope this will fix our release bodies being empty.