### PR TITLE
feat: `lx generate-rockspec`

### DIFF
--- a/lux-cli/src/bin/lx.rs
+++ b/lux-cli/src/bin/lx.rs
@@ -4,9 +4,9 @@ use clap::Parser;
 use lux_cli::{
     add, build, check, config,
     debug::Debug,
-    doc, download, exec, fetch, format, info, install, install_lua, install_rockspec, list,
-    outdated, pack, path, pin, project, purge, remove, run, run_lua, search, test, uninstall,
-    unpack, update,
+    doc, download, exec, fetch, format, generate_rockspec, info, install, install_lua,
+    install_rockspec, list, outdated, pack, path, pin, project, purge, remove, run, run_lua,
+    search, test, uninstall, unpack, update,
     upload::{self},
     which, Cli, Commands,
 };
@@ -95,5 +95,6 @@ async fn main() {
         }
         Commands::Which(which_args) => which::which(which_args, config).unwrap(),
         Commands::Run(run_args) => run::run(run_args, config).await.unwrap(),
+        Commands::GenerateRockspec(data) => generate_rockspec::generate_rockspec(data).unwrap(),
     }
 }

--- a/lux-cli/src/generate_rockspec.rs
+++ b/lux-cli/src/generate_rockspec.rs
@@ -1,0 +1,23 @@
+use clap::Args;
+use eyre::Result;
+use lux_lib::{project::Project, rockspec::Rockspec};
+
+#[derive(Args)]
+pub struct GenerateRockspec {}
+
+pub fn generate_rockspec(_data: GenerateRockspec) -> Result<()> {
+    let project = Project::current()?.unwrap();
+
+    let toml = project.toml().into_remote()?;
+    let rockspec = toml.to_lua_rockspec_string();
+
+    let path = project
+        .root()
+        .join(format!("{}-{}.rockspec", toml.package(), toml.version()));
+
+    std::fs::write(&path, rockspec)?;
+
+    println!("Wrote rockspec to {}", path.display());
+
+    Ok(())
+}

--- a/lux-cli/src/lib.rs
+++ b/lux-cli/src/lib.rs
@@ -9,6 +9,7 @@ use debug::Debug;
 use doc::Doc;
 use download::Download;
 use exec::Exec;
+use generate_rockspec::GenerateRockspec;
 use info::Info;
 use install::Install;
 use install_rockspec::InstallRockspec;
@@ -39,6 +40,7 @@ pub mod download;
 pub mod exec;
 pub mod fetch;
 pub mod format;
+pub mod generate_rockspec;
 pub mod info;
 pub mod install;
 pub mod install_lua;
@@ -147,6 +149,8 @@ pub enum Commands {
     Download(Download),
     /// Formats the codebase with stylua.
     Fmt,
+    /// Generate a rockspec file from a project.
+    GenerateRockspec(GenerateRockspec),
     /// Show metadata for any rock.
     Info(Info),
     /// Install a rock for use on the system.


### PR DESCRIPTION
This can come in handy for people who'd like to create a rockspec for interoperability purposes - Lux will also name the rockspec in accordance with how `luarocks` expects it.