### PR TITLE
fix: conflicting external dependency spec parse error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2328,7 +2328,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "getrandom 0.3.1",
+ "getrandom 0.2.15",
  "hashbrown 0.15.1",
  "hyper",
  "hyper-util",

--- a/lux-cli/resources/test/sample-project-init/lux.toml
+++ b/lux-cli/resources/test/sample-project-init/lux.toml
@@ -5,7 +5,7 @@ lua = ">=5.1"
 [description]
 summary = ""
 maintainer = "mrcjkb"
-labels = [ "" ]
+labels = [""]
 
 
 [dependencies]
@@ -13,7 +13,7 @@ labels = [ "" ]
 # `busted = ">=2.0"`
 
 [run]
-args = [ "src/main.lua" ]
+args = ["src/main.lua"]
 
 [build]
 type = "builtin"

--- a/lux-lib/resources/test/luaossl-20220711-0.rockspec
+++ b/lux-lib/resources/test/luaossl-20220711-0.rockspec
@@ -1,0 +1,154 @@
+package = "luaossl"
+version = "20220711-0"
+source = {
+	url = "https://github.com/wahern/luaossl/archive/rel-20220711.zip";
+	md5 = "6252043bfc22331f937b495ba3577156";
+	dir = "luaossl-rel-20220711";
+}
+description = {
+	summary = "Most comprehensive OpenSSL module in the Lua universe.";
+	homepage = "http://25thandclement.com/~william/projects/luaossl.html";
+	license = "MIT/X11";
+}
+supported_platforms = {
+	"unix";
+	"windows";
+}
+dependencies = {
+	"lua";
+}
+external_dependencies = {
+	OPENSSL = {
+		header = "openssl/ssl.h";
+		library = "ssl";
+	};
+	CRYPTO = {
+		header = "openssl/crypto.h";
+		library = "crypto";
+	};
+	platforms = {
+		windows = {
+			OPENSSL = {
+				library = "libeay32"
+			};
+			CRYPTO = {
+				library = "ssleay32"
+			};
+		}
+	};
+}
+build = {
+	type = "builtin";
+	modules = {
+		["_openssl"] = {
+			sources = {
+				"src/openssl.c";
+				"vendor/compat53/c-api/compat-5.3.c";
+			};
+			libraries = {
+				"ssl";
+				"crypto";
+			};
+			defines = {
+				"_REENTRANT"; "_THREAD_SAFE";
+				"COMPAT53_PREFIX=luaossl";
+			};
+			incdirs = {
+				"$(OPENSSL_INCDIR)";
+				"$(CRYPTO_INCDIR)";
+			};
+			libdirs = {
+				"$(OPENSSL_LIBDIR)";
+				"$(CRYPTO_LIBDIR)";
+			};
+		};
+		["openssl"] = "src/openssl.lua";
+		["openssl.auxlib"] = "src/openssl.auxlib.lua";
+		["openssl.bignum"] = "src/openssl.bignum.lua";
+		["openssl.cipher"] = "src/openssl.cipher.lua";
+		["openssl.des"] = "src/openssl.des.lua";
+		["openssl.digest"] = "src/openssl.digest.lua";
+		["openssl.hmac"] = "src/openssl.hmac.lua";
+		["openssl.kdf"] = "src/openssl.kdf.lua";
+		["openssl.ocsp.basic"] = "src/openssl.ocsp.basic.lua";
+		["openssl.ocsp.response"] = "src/openssl.ocsp.response.lua";
+		["openssl.pkcs12"] = "src/openssl.pkcs12.lua";
+		["openssl.pkey"] = "src/openssl.pkey.lua";
+		["openssl.pubkey"] = "src/openssl.pubkey.lua";
+		["openssl.rand"] = "src/openssl.rand.lua";
+		["openssl.ssl.context"] = "src/openssl.ssl.context.lua";
+		["openssl.ssl"] = "src/openssl.ssl.lua";
+		["openssl.x509"] = "src/openssl.x509.lua";
+		["openssl.x509.altname"] = "src/openssl.x509.altname.lua";
+		["openssl.x509.chain"] = "src/openssl.x509.chain.lua";
+		["openssl.x509.crl"] = "src/openssl.x509.crl.lua";
+		["openssl.x509.csr"] = "src/openssl.x509.csr.lua";
+		["openssl.x509.extension"] = "src/openssl.x509.extension.lua";
+		["openssl.x509.name"] = "src/openssl.x509.name.lua";
+		["openssl.x509.store"] = "src/openssl.x509.store.lua";
+		["openssl.x509.verify_param"] = "src/openssl.x509.verify_param.lua";
+	};
+	platforms = {
+		-- Unixy systems need to link with pthreads and libm.
+		-- We also define _GNU_SOURCE in the hope for extra functionality
+		unix = {
+			modules = {
+				["_openssl"] = {
+					libraries = {
+						nil, nil;
+						"pthread";
+						"m";
+					};
+					defines = {
+						nil, nil, nil;
+						"_GNU_SOURCE";
+					}
+				};
+			};
+		};
+		-- Only linux needs to link with libdl
+		linux = {
+			modules = {
+				["_openssl"] = {
+					libraries = {
+						nil, nil, nil, nil;
+						"dl";
+					};
+				};
+			};
+		};
+		-- On windows, OpenSSL libraries are named differently
+		-- We also have to guide autoguess around some incorrect assumptions
+		win32 = {
+			modules = {
+				["_openssl"] = {
+					libraries = {
+						"libeay32";
+						"ssleay32";
+						"ws2_32";
+						"advapi32";
+						"kernel32";
+					};
+					defines = {
+						nil, nil, nil;
+						"HAVE_SYS_PARAM_H=0";
+						"HAVE_DLFCN_H=0";
+						-- Need to set version to at least Vista to get inet_pton
+						"_WIN32_WINNT=0x0600";
+					};
+				};
+			};
+		};
+	};
+	patches = {
+		["config.h.diff"] = [[
+--- a/src/openssl.c
++++ b/src/openssl.c
+@@ -26,3 +26 @@
+-#if HAVE_CONFIG_H
+-#include "config.h"
+-#endif
++#include "../config.h.guess"
+]];
+	}
+}

--- a/lux-lib/src/lua_rockspec/dependency.rs
+++ b/lux-lib/src/lua_rockspec/dependency.rs
@@ -1,8 +1,8 @@
 use std::{collections::HashMap, convert::Infallible, path::PathBuf};
 
 use mlua::IntoLua;
+use path_slash::PathBufExt;
 use serde::Deserialize;
-use thiserror::Error;
 
 use super::{
     DisplayAsLuaKV, DisplayLuaKV, DisplayLuaValue, PartialOverride, PerPlatform,
@@ -10,60 +10,35 @@ use super::{
 };
 
 /// Can be defined in a [platform-agnostic](https://github.com/luarocks/luarocks/wiki/platform-agnostic-external-dependencies) manner
-#[derive(Debug, PartialEq, Clone)]
-pub enum ExternalDependencySpec {
+#[derive(Debug, PartialEq, Clone, Deserialize)]
+pub struct ExternalDependencySpec {
     /// A header file, e.g. "foo.h"
-    Header(PathBuf),
+    pub(crate) header: Option<PathBuf>,
     /// A library file, e.g. "libfoo.so"
-    Library(PathBuf),
+    pub(crate) library: Option<PathBuf>,
 }
 
 impl IntoLua for ExternalDependencySpec {
     fn into_lua(self, lua: &mlua::Lua) -> mlua::Result<mlua::Value> {
         let table = lua.create_table()?;
-
-        match self {
-            ExternalDependencySpec::Header(path) => {
-                table.set("header", path.to_string_lossy().to_string())?;
-            }
-            ExternalDependencySpec::Library(path) => {
-                table.set("library", path.to_string_lossy().to_string())?;
-            }
-        };
-
+        if let Some(path) = self.header {
+            table.set("header", path.to_slash_lossy().to_string())?;
+        }
+        if let Some(path) = self.library {
+            table.set("library", path.to_slash_lossy().to_string())?;
+        }
         Ok(mlua::Value::Table(table))
     }
 }
 
-#[derive(Error, Debug)]
-#[error("conflicting external dependency specification")]
-pub struct ConflictingExternalDependencySpec;
+impl PartialOverride for ExternalDependencySpec {
+    type Err = Infallible;
 
-#[derive(Error, Debug)]
-#[error("invalid external dependency key: {}", ._0)]
-pub struct InvalidExternalDependencyKey(String);
-
-impl<'de> Deserialize<'de> for ExternalDependencySpec {
-    fn deserialize<D>(deserializer: D) -> Result<ExternalDependencySpec, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let map: HashMap<String, PathBuf> = HashMap::deserialize(deserializer)?;
-
-        if map.contains_key("header") == map.contains_key("library") {
-            return Err(serde::de::Error::custom(ConflictingExternalDependencySpec));
-        }
-
-        match map.into_iter().next() {
-            Some((key, value)) => match key.as_str() {
-                "header" => Ok(ExternalDependencySpec::Header(value)),
-                "library" => Ok(ExternalDependencySpec::Library(value)),
-                key => Err(serde::de::Error::custom(InvalidExternalDependencyKey(
-                    key.to_string(),
-                ))),
-            },
-            None => unreachable!(),
-        }
+    fn apply_overrides(&self, override_val: &Self) -> Result<Self, Self::Err> {
+        Ok(Self {
+            header: override_val.header.clone().or(self.header.clone()),
+            library: override_val.library.clone().or(self.header.clone()),
+        })
     }
 }
 
@@ -73,10 +48,18 @@ impl PartialOverride for HashMap<String, ExternalDependencySpec> {
     fn apply_overrides(&self, override_map: &Self) -> Result<Self, Self::Err> {
         let mut result = Self::new();
         for (key, value) in self {
-            result.insert(key.clone(), value.clone());
+            result.insert(
+                key.clone(),
+                override_map
+                    .get(key)
+                    .map(|override_val| value.apply_overrides(override_val).expect("infallible"))
+                    .unwrap_or(value.clone()),
+            );
         }
         for (key, value) in override_map {
-            result.insert(key.clone(), value.clone());
+            if !result.contains_key(key) {
+                result.insert(key.clone(), value.clone());
+            }
         }
         Ok(result)
     }
@@ -103,18 +86,24 @@ impl DisplayAsLuaKV for ExternalDependencies<'_> {
             value: DisplayLuaValue::Table(
                 self.0
                     .iter()
-                    .map(|(key, value)| DisplayLuaKV {
-                        key: key.clone(),
-                        value: DisplayLuaValue::Table(match value {
-                            ExternalDependencySpec::Header(path) => vec![DisplayLuaKV {
+                    .map(|(key, value)| {
+                        let mut value_entries = Vec::new();
+                        if let Some(path) = &value.header {
+                            value_entries.push(DisplayLuaKV {
                                 key: "header".to_string(),
-                                value: DisplayLuaValue::String(path.to_string_lossy().to_string()),
-                            }],
-                            ExternalDependencySpec::Library(path) => vec![DisplayLuaKV {
+                                value: DisplayLuaValue::String(path.to_slash_lossy().to_string()),
+                            });
+                        }
+                        if let Some(path) = &value.library {
+                            value_entries.push(DisplayLuaKV {
                                 key: "library".to_string(),
-                                value: DisplayLuaValue::String(path.to_string_lossy().to_string()),
-                            }],
-                        }),
+                                value: DisplayLuaValue::String(path.to_slash_lossy().to_string()),
+                            });
+                        }
+                        DisplayLuaKV {
+                            key: key.clone(),
+                            value: DisplayLuaValue::Table(value_entries),
+                        }
                     })
                     .collect(),
             ),

--- a/lux-workspace-hack/Cargo.toml
+++ b/lux-workspace-hack/Cargo.toml
@@ -27,7 +27,7 @@ futures-channel = { version = "0.3", features = ["sink"] }
 futures-core = { version = "0.3" }
 futures-sink = { version = "0.3" }
 futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
-getrandom = { version = "0.3", default-features = false, features = ["std"] }
+getrandom = { version = "0.2", default-features = false, features = ["std"] }
 hashbrown = { version = "0.15" }
 hyper = { version = "1", features = ["client", "http1", "http2", "server"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "http1", "http2", "server"] }


### PR DESCRIPTION
Fixes #631.

Some rockspecs have both `header` and `library` fields in their `external_dependencies` table.
Lux only allowed one of them.