### PR TITLE
feat: git dependencies for local projects

### DIFF
--- a/lux-cli/src/build.rs
+++ b/lux-cli/src/build.rs
@@ -64,6 +64,7 @@ pub async fn build(data: Build, config: Config) -> Result<()> {
                 PackageInstallSpec::new(dep.clone().into_package_req(), tree::EntryType::Entrypoint)
                     .pin(*dep.pin())
                     .opt(*dep.opt())
+                    .maybe_source(dep.source().clone())
                     .build()
             });
 
@@ -84,6 +85,7 @@ pub async fn build(data: Build, config: Config) -> Result<()> {
                 PackageInstallSpec::new(dep.clone().into_package_req(), tree::EntryType::Entrypoint)
                     .pin(*dep.pin())
                     .opt(*dep.opt())
+                    .maybe_source(dep.source().clone())
                     .build()
             })
             .collect_vec();

--- a/lux-cli/src/install_rockspec.rs
+++ b/lux-cli/src/install_rockspec.rs
@@ -67,6 +67,7 @@ pub async fn install_rockspec(data: InstallRockspec, config: Config) -> Result<(
                 .build_behaviour(BuildBehaviour::NoForce)
                 .pin(pin)
                 .opt(OptState::Required)
+                .maybe_source(dep.source().clone())
                 .build()
         });
 

--- a/lux-lib/resources/test/sample-project-git-dependency/.gitignore
+++ b/lux-lib/resources/test/sample-project-git-dependency/.gitignore
@@ -1,0 +1,2 @@
+.lux/*
+lux.lock

--- a/lux-lib/resources/test/sample-project-git-dependency/lux.toml
+++ b/lux-lib/resources/test/sample-project-git-dependency/lux.toml
@@ -1,0 +1,10 @@
+package = "sample-project"
+version = "0.1.0"
+lua = "5.1"
+
+[dependencies.rustaceanvim]
+version = "v6.0.0"
+git = "github:mrcjkb/rustaceanvim"
+
+[build]
+type = "builtin"

--- a/lux-lib/src/build/mod.rs
+++ b/lux-lib/src/build/mod.rs
@@ -66,9 +66,6 @@ pub struct Build<'a, R: Rockspec + HasIntegrity> {
     #[builder(start_fn)]
     progress: &'a Progress<ProgressBar>,
 
-    #[builder(field)]
-    source_url: Option<RemotePackageSourceUrl>,
-
     #[builder(default)]
     pin: PinnedState,
     #[builder(default)]
@@ -78,18 +75,10 @@ pub struct Build<'a, R: Rockspec + HasIntegrity> {
     #[builder(default)]
     behaviour: BuildBehaviour,
 
+    source_url: Option<RemotePackageSourceUrl>,
+
     // TODO(vhyrro): Remove this and enforce that this is provided at a type level.
     source: Option<RemotePackageSource>,
-}
-
-impl<R: Rockspec + HasIntegrity, State> BuildBuilder<'_, R, State>
-where
-    State: build_builder::State,
-{
-    /// Override the source URL with one from a lockfile
-    pub(crate) fn source_url(self, source_url: Option<RemotePackageSourceUrl>) -> Self {
-        Self { source_url, ..self }
-    }
 }
 
 // Overwrite the `build()` function to use our own instead.

--- a/lux-lib/src/git/mod.rs
+++ b/lux-lib/src/git/mod.rs
@@ -1,0 +1,43 @@
+use git_url_parse::GitUrl;
+use mlua::UserData;
+
+use crate::lua_rockspec::{DisplayAsLuaKV, DisplayLuaKV, DisplayLuaValue};
+
+pub mod shorthand;
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct GitSource {
+    pub url: GitUrl,
+    pub checkout_ref: Option<String>,
+}
+
+impl UserData for GitSource {
+    fn add_methods<M: mlua::UserDataMethods<Self>>(methods: &mut M) {
+        methods.add_method("url", |_, this, _: ()| Ok(this.url.to_string()));
+        methods.add_method("checkout_ref", |_, this, _: ()| {
+            Ok(this.checkout_ref.clone())
+        });
+    }
+}
+
+impl DisplayAsLuaKV for GitSource {
+    fn display_lua(&self) -> DisplayLuaKV {
+        let mut source_tbl = Vec::new();
+        source_tbl.push(DisplayLuaKV {
+            key: "url".to_string(),
+            value: DisplayLuaValue::String(format!("{}", self.url)),
+        });
+        if let Some(checkout_ref) = &self.checkout_ref {
+            source_tbl.push(DisplayLuaKV {
+                // branches are not reproducible, so we will only ever generate tags.
+                // lux can also fetch revisions.
+                key: "tag".to_string(),
+                value: DisplayLuaValue::String(checkout_ref.to_string()),
+            });
+        }
+        DisplayLuaKV {
+            key: "source".to_string(),
+            value: DisplayLuaValue::Table(source_tbl),
+        }
+    }
+}

--- a/lux-lib/src/git/shorthand.rs
+++ b/lux-lib/src/git/shorthand.rs
@@ -1,0 +1,203 @@
+use std::{fmt::Display, str::FromStr};
+
+use chumsky::{prelude::*, Parser};
+use git_url_parse::GitUrl;
+use serde::{de, Deserialize, Deserializer};
+use thiserror::Error;
+
+const GITHUB: &str = "github";
+const GITLAB: &str = "gitlab";
+const SOURCEHUT: &str = "sourcehut";
+const CODEBERG: &str = "codeberg";
+
+#[derive(Debug, Error)]
+#[error("error parsing git source: {0:#?}")]
+pub struct ParseError(Vec<String>);
+
+/// Helper for parsing Git URLs from shorthands, e.g. "gitlab:owner/repo"
+#[derive(Debug)]
+pub(crate) struct GitUrlShorthand(GitUrl);
+
+impl FromStr for GitUrlShorthand {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match parser()
+            .parse(s)
+            .into_result()
+            .map_err(|err| ParseError(err.into_iter().map(|e| e.to_string()).collect()))
+        {
+            Ok(url) => Ok(url),
+            Err(err) => match s.parse() {
+                // fall back to parsing the URL directly
+                Ok(url) => Ok(Self(url)),
+                Err(_) => Err(err),
+            },
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for GitUrlShorthand {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        String::deserialize(deserializer)?
+            .parse()
+            .map_err(de::Error::custom)
+    }
+}
+
+impl From<GitUrl> for GitUrlShorthand {
+    fn from(value: GitUrl) -> Self {
+        Self(value)
+    }
+}
+
+impl From<GitUrlShorthand> for GitUrl {
+    fn from(value: GitUrlShorthand) -> Self {
+        value.0
+    }
+}
+
+#[derive(Debug, Default)]
+enum GitHost {
+    #[default]
+    Github,
+    Gitlab,
+    Sourcehut,
+    Codeberg,
+}
+
+fn parser<'a>() -> impl Parser<'a, &'a str, GitUrlShorthand, chumsky::extra::Err<Rich<'a, char>>> {
+    let git_host_prefix = just(GITHUB)
+        .or(just(GITLAB).or(just(SOURCEHUT).or(just(CODEBERG))))
+        .then_ignore(just(":"))
+        .or_not()
+        .map(|prefix| match prefix {
+            Some(GITHUB) => GitHost::Github,
+            Some(GITLAB) => GitHost::Gitlab,
+            Some(SOURCEHUT) => GitHost::Sourcehut,
+            Some(CODEBERG) => GitHost::Codeberg,
+            _ => GitHost::default(),
+        });
+    let owner_repo = none_of('/')
+        .repeated()
+        .collect::<String>()
+        .separated_by(just('/'))
+        .exactly(2)
+        .collect::<Vec<String>>()
+        .map(|v| (v[0].clone(), v[1].clone()));
+    git_host_prefix
+        .then(owner_repo)
+        .try_map(|(host, (owner, repo)), span| {
+            let url_str = match host {
+                GitHost::Github => format!("https://github.com/{}/{}.git", owner, repo),
+                GitHost::Gitlab => format!("https://gitlab.com/{}/{}.git", owner, repo),
+                GitHost::Sourcehut => format!("https://git.sr.ht/~{}/{}", owner, repo),
+                GitHost::Codeberg => format!("https://codeberg.org/~{}/{}.git", owner, repo),
+            };
+            let url = url_str.parse().map_err(|err| {
+                Rich::custom(span, format!("error parsing git url shorthand: {}", err))
+            })?;
+            Ok(GitUrlShorthand(url))
+        })
+}
+
+impl Display for GitUrlShorthand {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match (&self.0.host, &self.0.owner) {
+            (Some(host), Some(owner)) if host == "github.com" => {
+                format!("{}:{}/{}", GITHUB, owner, self.0.name)
+            }
+            (Some(host), Some(owner)) if host == "gitlab.com" => {
+                format!("{}:{}/{}", GITLAB, owner, self.0.name)
+            }
+            (Some(host), Some(owner)) if host == "git.sr.ht" => {
+                format!("{}:{}/{}", SOURCEHUT, owner.replace('~', ""), self.0.name)
+            }
+            (Some(host), Some(owner)) if host == "codeberg.org" => {
+                format!("{}:{}/{}", CODEBERG, owner.replace('~', ""), self.0.name)
+            }
+            _ => format!("{}", self.0),
+        }
+        .fmt(f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn owner_repo_shorthand() {
+        let url_shorthand: GitUrlShorthand = "nvim-neorocks/lux".parse().unwrap();
+        assert_eq!(url_shorthand.0.owner, Some("nvim-neorocks".to_string()));
+        assert_eq!(url_shorthand.0.name, "lux".to_string());
+    }
+
+    #[tokio::test]
+    async fn github_shorthand() {
+        let url_shorthand_str = "github:nvim-neorocks/lux";
+        let url_shorthand: GitUrlShorthand = url_shorthand_str.parse().unwrap();
+        assert_eq!(url_shorthand.0.host, Some("github.com".to_string()));
+        assert_eq!(url_shorthand.0.owner, Some("nvim-neorocks".to_string()));
+        assert_eq!(url_shorthand.0.name, "lux".to_string());
+        assert_eq!(url_shorthand.to_string(), url_shorthand_str.to_string());
+    }
+
+    #[tokio::test]
+    async fn gitlab_shorthand() {
+        let url_shorthand_str = "gitlab:nvim-neorocks/lux";
+        let url_shorthand: GitUrlShorthand = url_shorthand_str.parse().unwrap();
+        assert_eq!(url_shorthand.0.host, Some("gitlab.com".to_string()));
+        assert_eq!(url_shorthand.0.owner, Some("nvim-neorocks".to_string()));
+        assert_eq!(url_shorthand.0.name, "lux".to_string());
+        assert_eq!(url_shorthand.to_string(), url_shorthand_str.to_string());
+    }
+
+    #[tokio::test]
+    async fn sourcehut_shorthand() {
+        let url_shorthand_str = "sourcehut:nvim-neorocks/lux";
+        let url_shorthand: GitUrlShorthand = url_shorthand_str.parse().unwrap();
+        assert_eq!(url_shorthand.0.host, Some("git.sr.ht".to_string()));
+        assert_eq!(url_shorthand.0.owner, Some("~nvim-neorocks".to_string()));
+        assert_eq!(url_shorthand.0.name, "lux".to_string());
+        assert_eq!(url_shorthand.to_string(), url_shorthand_str.to_string());
+    }
+
+    #[tokio::test]
+    async fn codeberg_shorthand() {
+        let url_shorthand_str = "codeberg:nvim-neorocks/lux";
+        let url_shorthand: GitUrlShorthand = url_shorthand_str.parse().unwrap();
+        assert_eq!(url_shorthand.0.host, Some("codeberg.org".to_string()));
+        assert_eq!(url_shorthand.0.owner, Some("~nvim-neorocks".to_string()));
+        assert_eq!(url_shorthand.0.name, "lux".to_string());
+        assert_eq!(url_shorthand.to_string(), url_shorthand_str.to_string());
+    }
+
+    #[tokio::test]
+    async fn regular_https_url() {
+        let url_shorthand: GitUrlShorthand =
+            "https://github.com/nvim-neorocks/lux.git".parse().unwrap();
+        assert_eq!(url_shorthand.0.host, Some("github.com".to_string()));
+        assert_eq!(url_shorthand.0.owner, Some("nvim-neorocks".to_string()));
+        assert_eq!(url_shorthand.0.name, "lux".to_string());
+        assert_eq!(
+            url_shorthand.to_string(),
+            "github:nvim-neorocks/lux".to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn regular_ssh_url() {
+        let url_str = "git@github.com:nvim-neorocks/lux.git";
+        let url_shorthand: GitUrlShorthand = url_str.parse().unwrap();
+        assert_eq!(url_shorthand.0.host, Some("github.com".to_string()));
+        assert_eq!(
+            url_shorthand.0.owner,
+            Some("git@github.com:nvim-neorocks".to_string())
+        );
+        assert_eq!(url_shorthand.0.name, "lux".to_string());
+    }
+}

--- a/lux-lib/src/lib.rs
+++ b/lux-lib/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod build;
 pub mod config;
+pub mod git;
 pub mod hash;
 pub mod lockfile;
 pub mod lua_installation;

--- a/lux-lib/src/lockfile/mod.rs
+++ b/lux-lib/src/lockfile/mod.rs
@@ -493,6 +493,10 @@ impl LocalPackage {
         self.spec.opt()
     }
 
+    pub(crate) fn source(&self) -> &RemotePackageSource {
+        &self.source
+    }
+
     pub fn dependencies(&self) -> Vec<&LocalPackageId> {
         self.spec.dependencies()
     }

--- a/lux-lib/src/lua_rockspec/mod.rs
+++ b/lux-lib/src/lua_rockspec/mod.rs
@@ -40,6 +40,12 @@ pub enum LuaRockspecError {
     CopyDirectoriesContainRockspecName(Option<String>),
     #[error("could not parse rockspec: {0}")]
     LuaTable(#[from] LuaTableError),
+    #[error("cannot create Lua rockspec with off-spec dependency: {0}")]
+    OffSpecDependency(PackageName),
+    #[error("cannot create Lua rockspec with off-spec build dependency: {0}")]
+    OffSpecBuildDependency(PackageName),
+    #[error("cannot create Lua rockspec with off-spec test dependency: {0}")]
+    OffSpecTestDependency(PackageName),
 }
 
 #[derive(Clone, Debug)]
@@ -622,6 +628,7 @@ mod tests {
 
     use std::path::PathBuf;
 
+    use crate::git::GitSource;
     use crate::lua_rockspec::PlatformIdentifier;
     use crate::package::PackageSpec;
 

--- a/lux-lib/src/lua_rockspec/rock_source.rs
+++ b/lux-lib/src/lua_rockspec/rock_source.rs
@@ -6,6 +6,8 @@ use ssri::Integrity;
 use std::{convert::Infallible, fs, io, ops::Deref, path::PathBuf, str::FromStr};
 use thiserror::Error;
 
+use crate::git::GitSource;
+
 use super::{
     DisplayAsLuaKV, DisplayLuaKV, DisplayLuaValue, FromPlatformOverridable, PartialOverride,
     PerPlatform, PerPlatformWrapper, PlatformOverridable,
@@ -190,43 +192,6 @@ impl DisplayAsLuaKV for RockSourceSpec {
                     value: DisplayLuaValue::Table(source_tbl),
                 }
             }
-        }
-    }
-}
-
-#[derive(Debug, PartialEq, Clone)]
-pub struct GitSource {
-    pub url: GitUrl,
-    pub checkout_ref: Option<String>,
-}
-
-impl UserData for GitSource {
-    fn add_methods<M: mlua::UserDataMethods<Self>>(methods: &mut M) {
-        methods.add_method("url", |_, this, _: ()| Ok(this.url.to_string()));
-        methods.add_method("checkout_ref", |_, this, _: ()| {
-            Ok(this.checkout_ref.clone())
-        });
-    }
-}
-
-impl DisplayAsLuaKV for GitSource {
-    fn display_lua(&self) -> DisplayLuaKV {
-        let mut source_tbl = Vec::new();
-        source_tbl.push(DisplayLuaKV {
-            key: "url".to_string(),
-            value: DisplayLuaValue::String(format!("{}", self.url)),
-        });
-        if let Some(checkout_ref) = &self.checkout_ref {
-            source_tbl.push(DisplayLuaKV {
-                // branches are not reproducible, so we will only ever generate tags.
-                // lux can also fetch revisions.
-                key: "tag".to_string(),
-                value: DisplayLuaValue::String(checkout_ref.to_string()),
-            });
-        }
-        DisplayLuaKV {
-            key: "source".to_string(),
-            value: DisplayLuaValue::Table(source_tbl),
         }
     }
 }

--- a/lux-lib/src/operations/download.rs
+++ b/lux-lib/src/operations/download.rs
@@ -10,8 +10,9 @@ use url::{ParseError, Url};
 
 use crate::{
     config::Config,
+    git::GitSource,
     lockfile::RemotePackageSourceUrl,
-    lua_rockspec::{GitSource, LuaRockspecError, RemoteLuaRockspec, RockSourceSpec},
+    lua_rockspec::{LuaRockspecError, RemoteLuaRockspec, RockSourceSpec},
     luarocks,
     package::{
         PackageName, PackageReq, PackageSpec, PackageSpecFromPackageReqError, PackageVersion,

--- a/lux-lib/src/operations/fetch.rs
+++ b/lux-lib/src/operations/fetch.rs
@@ -12,9 +12,9 @@ use thiserror::Error;
 
 use crate::build::utils::recursive_copy_dir;
 use crate::config::Config;
+use crate::git::GitSource;
 use crate::hash::HasIntegrity;
 use crate::lockfile::RemotePackageSourceUrl;
-use crate::lua_rockspec::GitSource;
 use crate::lua_rockspec::RockSourceSpec;
 use crate::operations;
 use crate::package::PackageSpec;

--- a/lux-lib/src/operations/install.rs
+++ b/lux-lib/src/operations/install.rs
@@ -359,7 +359,7 @@ async fn install_rockspec(
         .constraint(constraint)
         .behaviour(behaviour)
         .source(source)
-        .source_url(rockspec_download.source_url)
+        .maybe_source_url(rockspec_download.source_url)
         .build()
         .await
         .map_err(|err| InstallError::BuildError(package, err))?;

--- a/lux-lib/src/operations/install_spec.rs
+++ b/lux-lib/src/operations/install_spec.rs
@@ -22,8 +22,8 @@ pub struct PackageInstallSpec {
     pub(crate) pin: PinnedState,
     #[builder(default)]
     pub(crate) opt: OptState,
+    pub(crate) source: Option<RockSourceSpec>,
     /// Optional constraint, carried over from a previous install,
     /// e.g. defined in a lockfile.
     pub(crate) constraint: Option<LockConstraint>,
-    pub(crate) source: Option<RockSourceSpec>,
 }

--- a/lux-lib/src/operations/resolve.rs
+++ b/lux-lib/src/operations/resolve.rs
@@ -113,6 +113,7 @@ where
                                     .build_behaviour(build_behaviour)
                                     .pin(pin)
                                     .opt(opt)
+                                    .maybe_source(dep.source().clone())
                                     .build()
                             })
                             .collect_vec();

--- a/lux-lib/src/operations/sync.rs
+++ b/lux-lib/src/operations/sync.rs
@@ -220,11 +220,12 @@ async fn do_sync(
 
     if !package_sync_spec.to_add.is_empty() {
         // Install missing packages using the default package_db.
-        let missing_packages = package_sync_spec.to_add.into_iter().map(|pkg| {
-            PackageInstallSpec::new(pkg.package_req().clone(), tree::EntryType::Entrypoint)
+        let missing_packages = package_sync_spec.to_add.into_iter().map(|dep| {
+            PackageInstallSpec::new(dep.package_req().clone(), tree::EntryType::Entrypoint)
                 .build_behaviour(BuildBehaviour::Force)
-                .pin(*pkg.pin())
-                .opt(*pkg.opt())
+                .pin(*dep.pin())
+                .opt(*dep.opt())
+                .maybe_source(dep.source.clone())
                 .build()
         });
 

--- a/lux-lib/src/operations/test.rs
+++ b/lux-lib/src/operations/test.rs
@@ -241,6 +241,7 @@ async fn ensure_dependencies(
                     .build_behaviour(build_behaviour)
                     .pin(*dep.pin())
                     .opt(*dep.opt())
+                    .maybe_source(dep.source.clone())
                     .build()
             })
         });
@@ -270,6 +271,7 @@ async fn ensure_dependencies(
                     .build_behaviour(build_behaviour)
                     .pin(*dep.pin())
                     .opt(*dep.opt())
+                    .maybe_source(dep.source().clone())
                     .build()
             })
         });

--- a/lux-lib/src/project/mod.rs
+++ b/lux-lib/src/project/mod.rs
@@ -519,6 +519,7 @@ impl Project {
         if let Some(dependencies) = &self.toml().dependencies {
             let packages = dependencies
                 .iter()
+                .filter(|dep| dep.source().is_none()) // We don't support upgrading git sources for now
                 .map(|dep| dep.name())
                 .cloned()
                 .collect_vec();
@@ -528,6 +529,7 @@ impl Project {
         if let Some(dependencies) = &self.toml().build_dependencies {
             let packages = dependencies
                 .iter()
+                .filter(|dep| dep.source().is_none())
                 .map(|dep| dep.name())
                 .cloned()
                 .collect_vec();
@@ -537,6 +539,7 @@ impl Project {
         if let Some(dependencies) = &self.toml().test_dependencies {
             let packages = dependencies
                 .iter()
+                .filter(|dep| dep.source().is_none())
                 .map(|dep| dep.name())
                 .cloned()
                 .collect_vec();

--- a/lux-lib/src/rockspec/lua_dependency.rs
+++ b/lux-lib/src/rockspec/lua_dependency.rs
@@ -6,7 +6,9 @@ use thiserror::Error;
 
 use crate::{
     lockfile::{OptState, PinnedState},
-    lua_rockspec::{ExternalDependencySpec, PartialOverride, PerPlatform, PlatformOverridable},
+    lua_rockspec::{
+        ExternalDependencySpec, PartialOverride, PerPlatform, PlatformOverridable, RockSourceSpec,
+    },
     package::{PackageName, PackageReq, PackageReqParseError, PackageSpec, PackageVersionReq},
 };
 
@@ -21,16 +23,10 @@ pub struct LuaDependencySpec {
     pub(crate) package_req: PackageReq,
     pub(crate) pin: PinnedState,
     pub(crate) opt: OptState,
+    pub(crate) source: Option<RockSourceSpec>,
 }
 
 impl LuaDependencySpec {
-    pub fn new(package_req: PackageReq, pin: PinnedState, opt: OptState) -> Self {
-        Self {
-            package_req,
-            pin,
-            opt,
-        }
-    }
     pub fn package_req(&self) -> &PackageReq {
         &self.package_req
     }
@@ -39,6 +35,9 @@ impl LuaDependencySpec {
     }
     pub fn opt(&self) -> &OptState {
         &self.opt
+    }
+    pub fn source(&self) -> &Option<RockSourceSpec> {
+        &self.source
     }
     pub fn into_package_req(self) -> PackageReq {
         self.package_req
@@ -60,6 +59,7 @@ impl From<PackageName> for LuaDependencySpec {
             package_req: PackageReq::from(name),
             pin: PinnedState::default(),
             opt: OptState::default(),
+            source: None,
         }
     }
 }
@@ -70,6 +70,7 @@ impl From<PackageReq> for LuaDependencySpec {
             package_req,
             pin: PinnedState::default(),
             opt: OptState::default(),
+            source: None,
         }
     }
 }
@@ -83,6 +84,7 @@ impl FromStr for LuaDependencySpec {
             package_req,
             pin: PinnedState::default(),
             opt: OptState::default(),
+            source: None,
         })
     }
 }
@@ -137,6 +139,7 @@ impl FromLua for LuaDependencySpec {
             package_req,
             pin: PinnedState::default(),
             opt: OptState::default(),
+            source: None,
         })
     }
 }
@@ -151,6 +154,7 @@ impl<'de> Deserialize<'de> for LuaDependencySpec {
             package_req,
             pin: PinnedState::default(),
             opt: OptState::default(),
+            source: None,
         })
     }
 }

--- a/lux-lib/src/upload/mod.rs
+++ b/lux-lib/src/upload/mod.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use crate::lua_rockspec::{GitSource, LocalRockSource, RemoteRockSource, RockSourceSpec};
+use crate::lua_rockspec::{LocalRockSource, RemoteRockSource, RockSourceSpec};
 use crate::project::project_toml::RemoteProjectTomlValidationError;
 use crate::rockspec::Rockspec;
 use crate::TOOL_VERSION;
@@ -298,6 +298,7 @@ async fn upload_from_project(
 
 mod helpers {
     use super::*;
+    use crate::git::GitSource;
     use crate::package::{PackageName, PackageVersion};
     use crate::upload::RockCheckError;
     use crate::upload::{ToolCheckError, UserCheckError};

--- a/lux-lib/tests/install.rs
+++ b/lux-lib/tests/install.rs
@@ -1,8 +1,9 @@
 use assert_fs::TempDir;
 use lux_lib::{
     config::{ConfigBuilder, LuaVersion},
+    git::GitSource,
     lua_installation::get_installed_lua_version,
-    lua_rockspec::{GitSource, RockSourceSpec},
+    lua_rockspec::RockSourceSpec,
     operations::{Install, PackageInstallSpec},
     tree::EntryType,
 };


### PR DESCRIPTION
This adds basic support for git dependencies in a local project.

- Errors if trying to convert to a Lua rockspec.
- `lx add/remove/update` are not implemented yet (see the new issues).

Stacked on #629.
Closes #329.