### PR TITLE
fix(build): transitive dependencies added as dependencies of main rock

### DIFF
--- a/lux-cli/src/build.rs
+++ b/lux-cli/src/build.rs
@@ -157,6 +157,7 @@ Use --no-lock to force a new build.
         lockfile.add_entrypoint(&package);
         for dep in dependencies {
             lockfile.add_dependency(&package, &dep);
+            lockfile.remove_entrypoint(&dep);
         }
     }
 

--- a/lux-cli/src/build.rs
+++ b/lux-cli/src/build.rs
@@ -144,7 +144,13 @@ Use --no-lock to force a new build.
         let dependencies = lockfile
             .rocks()
             .iter()
-            .map(|(_, value)| value)
+            .filter_map(|(pkg_id, value)| {
+                if lockfile.is_entrypoint(pkg_id) {
+                    Some(value)
+                } else {
+                    None
+                }
+            })
             .cloned()
             .collect_vec();
         let mut lockfile = lockfile.write_guard();

--- a/lux-lib/src/lockfile/mod.rs
+++ b/lux-lib/src/lockfile/mod.rs
@@ -1205,6 +1205,17 @@ impl Lockfile<ReadWrite> {
         self.lock.entrypoints.push(rock.id().clone())
     }
 
+    pub fn remove_entrypoint(&mut self, rock: &LocalPackage) {
+        if let Some(index) = self
+            .lock
+            .entrypoints
+            .iter()
+            .position(|pkg_id| *pkg_id == rock.id())
+        {
+            self.lock.entrypoints.remove(index);
+        }
+    }
+
     fn add(&mut self, rock: &LocalPackage) {
         self.lock.rocks.insert(rock.id(), rock.clone());
     }


### PR DESCRIPTION
When running `lx build`, the entry for the built rock in the install tree's lux.lock has all transitive dependencies listed as dependencies.