### PR TITLE
fix(build): dependencies added as install tree entrypoints

### DIFF
--- a/lux-cli/src/build.rs
+++ b/lux-cli/src/build.rs
@@ -157,6 +157,7 @@ Use --no-lock to force a new build.
         lockfile.add_entrypoint(&package);
         for dep in dependencies {
             lockfile.add_dependency(&package, &dep);
+            lockfile.remove_entrypoint(&dep);
         }
     }
 

--- a/lux-lib/src/lockfile/mod.rs
+++ b/lux-lib/src/lockfile/mod.rs
@@ -1205,6 +1205,17 @@ impl Lockfile<ReadWrite> {
         self.lock.entrypoints.push(rock.id().clone())
     }
 
+    pub fn remove_entrypoint(&mut self, rock: &LocalPackage) {
+        if let Some(index) = self
+            .lock
+            .entrypoints
+            .iter()
+            .position(|pkg_id| *pkg_id == rock.id())
+        {
+            self.lock.entrypoints.remove(index);
+        }
+    }
+
     fn add(&mut self, rock: &LocalPackage) {
         self.lock.rocks.insert(rock.id(), rock.clone());
     }


### PR DESCRIPTION
Stacked on #650.

Because we install dependencies before building a local project, they get added to the install tree's lux.toml as entrypoints.
When installing the local project as a rock, we want it to be the only entrypoint.