### PR TITLE
feat(cli): nicer error messages

### DIFF
--- a/lux-cli/src/bin/lx.rs
+++ b/lux-cli/src/bin/lx.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use clap::Parser;
+use eyre::Result;
 use lux_cli::{
     add, build, check, config,
     debug::Debug,
@@ -16,7 +17,7 @@ use lux_lib::{
 };
 
 #[tokio::main(flavor = "multi_thread")]
-async fn main() {
+async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     let mut config_builder = ConfigBuilder::new()
@@ -40,61 +41,50 @@ async fn main() {
         config_builder = config_builder.entrypoint_layout(RockLayoutConfig::new_nvim_layout());
     }
 
-    let config = config_builder.build().unwrap();
+    let config = config_builder.build()?;
 
     match cli.command {
-        Commands::Search(search_data) => search::search(search_data, config).await.unwrap(),
-        Commands::Download(download_data) => {
-            download::download(download_data, config).await.unwrap()
-        }
+        Commands::Search(search_data) => search::search(search_data, config).await?,
+        Commands::Download(download_data) => download::download(download_data, config).await?,
         Commands::Debug(debug) => match debug {
-            Debug::FetchRemote(unpack_data) => {
-                fetch::fetch_remote(unpack_data, config).await.unwrap()
-            }
-            Debug::Unpack(unpack_data) => unpack::unpack(unpack_data).await.unwrap(),
-            Debug::UnpackRemote(unpack_data) => {
-                unpack::unpack_remote(unpack_data, config).await.unwrap()
-            }
-            Debug::Project(debug_project) => project::debug_project(debug_project).unwrap(),
+            Debug::FetchRemote(unpack_data) => fetch::fetch_remote(unpack_data, config).await?,
+            Debug::Unpack(unpack_data) => unpack::unpack(unpack_data).await?,
+            Debug::UnpackRemote(unpack_data) => unpack::unpack_remote(unpack_data, config).await?,
+            Debug::Project(debug_project) => project::debug_project(debug_project)?,
         },
-        Commands::New(project_data) => project::write_project_rockspec(project_data).await.unwrap(),
-        Commands::Build(build_data) => build::build(build_data, config).await.unwrap(),
-        Commands::List(list_data) => list::list_installed(list_data, config).unwrap(),
-        Commands::Lua(run_lua) => run_lua::run_lua(run_lua, config).await.unwrap(),
-        Commands::Install(install_data) => install::install(install_data, config).await.unwrap(),
+        Commands::New(project_data) => project::write_project_rockspec(project_data).await?,
+        Commands::Build(build_data) => build::build(build_data, config).await?,
+        Commands::List(list_data) => list::list_installed(list_data, config)?,
+        Commands::Lua(run_lua) => run_lua::run_lua(run_lua, config).await?,
+        Commands::Install(install_data) => install::install(install_data, config).await?,
         Commands::InstallRockspec(install_data) => {
-            install_rockspec::install_rockspec(install_data, config)
-                .await
-                .unwrap()
+            install_rockspec::install_rockspec(install_data, config).await?
         }
-        Commands::Outdated(outdated) => outdated::outdated(outdated, config).await.unwrap(),
-        Commands::InstallLua => install_lua::install_lua(config).await.unwrap(),
-        Commands::Fmt => format::format().unwrap(),
-        Commands::Purge => purge::purge(config).await.unwrap(),
-        Commands::Remove(remove_args) => remove::remove(remove_args, config).await.unwrap(),
-        Commands::Exec(run_args) => exec::exec(run_args, config).await.unwrap(),
-        Commands::Test(test) => test::test(test, config).await.unwrap(),
-        Commands::Update(update_args) => update::update(update_args, config).await.unwrap(),
-        Commands::Info(info_data) => info::info(info_data, config).await.unwrap(),
-        Commands::Path(path_data) => path::path(path_data, config).await.unwrap(),
-        Commands::Pin(pin_data) => pin::set_pinned_state(pin_data, config, Pinned)
-            .await
-            .unwrap(),
-        Commands::Unpin(pin_data) => pin::set_pinned_state(pin_data, config, Unpinned)
-            .await
-            .unwrap(),
-        Commands::Upload(upload_data) => upload::upload(upload_data, config).await.unwrap(),
-        Commands::Check => check::check(config).await.unwrap(),
-        Commands::Add(add_data) => add::add(add_data, config).await.unwrap(),
-        Commands::Config(config_cmd) => config::config(config_cmd, config).unwrap(),
-        Commands::Doc(doc_args) => doc::doc(doc_args, config).await.unwrap(),
+        Commands::Outdated(outdated) => outdated::outdated(outdated, config).await?,
+        Commands::InstallLua => install_lua::install_lua(config).await?,
+        Commands::Fmt => format::format()?,
+        Commands::Purge => purge::purge(config).await?,
+        Commands::Remove(remove_args) => remove::remove(remove_args, config).await?,
+        Commands::Exec(run_args) => exec::exec(run_args, config).await?,
+        Commands::Test(test) => test::test(test, config).await?,
+        Commands::Update(update_args) => update::update(update_args, config).await?,
+        Commands::Info(info_data) => info::info(info_data, config).await?,
+        Commands::Path(path_data) => path::path(path_data, config).await?,
+        Commands::Pin(pin_data) => pin::set_pinned_state(pin_data, config, Pinned).await?,
+        Commands::Unpin(pin_data) => pin::set_pinned_state(pin_data, config, Unpinned).await?,
+        Commands::Upload(upload_data) => upload::upload(upload_data, config).await?,
+        Commands::Check => check::check(config).await?,
+        Commands::Add(add_data) => add::add(add_data, config).await?,
+        Commands::Config(config_cmd) => config::config(config_cmd, config)?,
+        Commands::Doc(doc_args) => doc::doc(doc_args, config).await?,
         Commands::Lint => unimplemented!(),
-        Commands::Pack(pack_args) => pack::pack(pack_args, config).await.unwrap(),
+        Commands::Pack(pack_args) => pack::pack(pack_args, config).await?,
         Commands::Uninstall(uninstall_data) => {
             uninstall::uninstall(uninstall_data, config).await.unwrap()
         }
-        Commands::Which(which_args) => which::which(which_args, config).unwrap(),
-        Commands::Run(run_args) => run::run(run_args, config).await.unwrap(),
-        Commands::GenerateRockspec(data) => generate_rockspec::generate_rockspec(data).unwrap(),
+        Commands::Which(which_args) => which::which(which_args, config)?,
+        Commands::Run(run_args) => run::run(run_args, config).await?,
+        Commands::GenerateRockspec(data) => generate_rockspec::generate_rockspec(data)?,
     }
+    Ok(())
 }


### PR DESCRIPTION
I think this should get rid of rust messages like

```
thread 'main' panicked at <path>/src/bin/lx.rs:63:75:
called `Result::unwrap()` on an `Err` value: <eyre-error-message>
```

and instead just display the `<eyre-error-message>`.