### PR TITLE
refactor!: unify `Sync` by making it take in a `Project`

### DIFF
--- a/lux-cli/src/build.rs
+++ b/lux-cli/src/build.rs
@@ -101,11 +101,8 @@ pub async fn build(data: Build, config: Config) -> Result<()> {
                 .await?;
         }
     } else {
-        let mut project_lockfile = project.lockfile()?.write_guard();
-
-        Sync::new(&tree, &mut project_lockfile, &config)
+        Sync::new(&project, &config)
             .progress(progress.clone())
-            .packages(dependencies)
             .sync_dependencies()
             .await
             .wrap_err(
@@ -115,9 +112,8 @@ Use --no-lock to force a new build.
 ",
             )?;
 
-        Sync::new(luarocks.tree(), &mut project_lockfile, luarocks.config())
+        Sync::new(&project, luarocks.config())
             .progress(progress.clone())
-            .packages(build_dependencies)
             .sync_build_dependencies()
             .await
             .wrap_err(

--- a/lux-cli/src/utils/project.rs
+++ b/lux-cli/src/utils/project.rs
@@ -7,7 +7,6 @@ use lux_lib::{
     operations::Sync,
     progress::{MultiProgress, Progress},
     project::Project,
-    rockspec::Rockspec,
 };
 
 pub async fn sync_dependencies_if_locked(
@@ -17,22 +16,11 @@ pub async fn sync_dependencies_if_locked(
 ) -> Result<()> {
     // NOTE: We only update the lockfile if one exists.
     // Otherwise, the next `lx build` will remove the packages.
-    if let Some(lockfile) = project.try_lockfile()? {
-        let mut lockfile = lockfile.write_guard();
-        let tree = project.tree(config)?;
-        let packages = project
-            .toml()
-            .into_local()?
-            .dependencies()
-            .current_platform()
-            .clone();
-        Sync::new(&tree, &mut lockfile, config)
-            .packages(packages)
-            .progress(progress)
-            .sync_dependencies()
-            .await
-            .wrap_err("syncing dependencies with the project lockfile failed.")?;
-    }
+    Sync::new(project, config)
+        .progress(progress)
+        .sync_dependencies()
+        .await
+        .wrap_err("syncing dependencies with the project lockfile failed.")?;
     Ok(())
 }
 
@@ -41,22 +29,13 @@ pub async fn sync_build_dependencies_if_locked(
     progress: Arc<Progress<MultiProgress>>,
     config: &Config,
 ) -> Result<()> {
-    if let Some(lockfile) = project.try_lockfile()? {
-        let luarocks = LuaRocksInstallation::new(config)?;
-        let mut lockfile = lockfile.write_guard();
-        let packages = project
-            .toml()
-            .into_local()?
-            .build_dependencies()
-            .current_platform()
-            .clone();
-        Sync::new(luarocks.tree(), &mut lockfile, luarocks.config())
-            .packages(packages)
-            .progress(progress.clone())
-            .sync_build_dependencies()
-            .await
-            .wrap_err("syncing build dependencies with the project lockfile failed.")?;
-    }
+    let luarocks = LuaRocksInstallation::new(config)?;
+    Sync::new(project, luarocks.config())
+        .progress(progress.clone())
+        .custom_tree(luarocks.tree())
+        .sync_build_dependencies()
+        .await
+        .wrap_err("syncing build dependencies with the project lockfile failed.")?;
     Ok(())
 }
 
@@ -65,21 +44,10 @@ pub async fn sync_test_dependencies_if_locked(
     progress: Arc<Progress<MultiProgress>>,
     config: &Config,
 ) -> Result<()> {
-    if let Some(lockfile) = project.try_lockfile()? {
-        let mut lockfile = lockfile.write_guard();
-        let packages = project
-            .toml()
-            .into_local()?
-            .test_dependencies()
-            .current_platform()
-            .clone();
-        let tree = project.test_tree(config)?;
-        Sync::new(&tree, &mut lockfile, config)
-            .packages(packages)
-            .progress(progress.clone())
-            .sync_test_dependencies()
-            .await
-            .wrap_err("syncing test dependencies with the project lockfile failed.")?;
-    }
+    Sync::new(project, config)
+        .progress(progress.clone())
+        .sync_test_dependencies()
+        .await
+        .wrap_err("syncing test dependencies with the project lockfile failed.")?;
     Ok(())
 }

--- a/lux-lib/src/operations/test.rs
+++ b/lux-lib/src/operations/test.rs
@@ -113,32 +113,13 @@ async fn run_tests(test: Test<'_>) -> Result<(), RunTestsError> {
         )
         .await?;
     } else {
-        let mut lockfile = test.project.lockfile()?.write_guard();
-
-        let test_dependencies = rocks
-            .test_dependencies()
-            .current_platform()
-            .iter()
-            .cloned()
-            .collect_vec();
-
-        Sync::new(&test_tree, &mut lockfile, test.config)
+        Sync::new(&test.project, test.config)
             .progress(test.progress.clone())
-            .packages(test_dependencies)
             .sync_test_dependencies()
             .await?;
 
-        let dependencies = rocks
-            .dependencies()
-            .current_platform()
-            .iter()
-            .filter(|req| !req.name().eq(&PackageName::new("lua".into())))
-            .cloned()
-            .collect_vec();
-
-        Sync::new(&project_tree, &mut lockfile, test.config)
+        Sync::new(&test.project, test.config)
             .progress(test.progress.clone())
-            .packages(dependencies)
             .sync_dependencies()
             .await?;
     }


### PR DESCRIPTION
this unifies the API and further prevents mistakes.

one extra issue: we always build a luarocks installation for build dependencies - shouldn't we incorporate this deeper into the API (e.g. as part of `Sync`), instead of hoping that users provide the correct tree? That should be for a different PR, and I make an issue for that if you'd wish :)
