### PR TITLE
feat(cli): `lx add` for git dependencies

### DIFF
--- a/
+++ b/
@@ -68,14 +68,10 @@ pub enum IntoRemoteRockspecError {
 }
 
 #[derive(Error, Debug)]
+#[error(transparent)]
 pub enum ProjectEditError {
-    #[error(transparent)]
     Io(#[from] tokio::io::Error),
-    #[error(transparent)]
     Toml(#[from] toml_edit::TomlError),
-    #[error("error parsing lux.toml after edit. This is probably a bug.")]
-    TomlDe(#[from] toml::de::Error),
-    #[error(transparent)]
     Git(#[from] GitError),
 }
 
@@ -97,8 +93,6 @@ pub enum PinError {
     },
     #[error(transparent)]
     Toml(#[from] toml_edit::TomlError),
-    #[error("error parsing lux.toml after edit. This is probably a bug.")]
-    TomlDe(#[from] toml::de::Error),
     #[error(transparent)]
     Io(#[from] tokio::io::Error),
 }
@@ -410,9 +404,54 @@ impl Project {
             }
         };
 
-        let toml_content = project_toml.to_string();
-        tokio::fs::write(self.toml_path(), &toml_content).await?;
-        self.toml = PartialProjectToml::new(&toml_content, self.root.clone())?;
+        tokio::fs::write(self.toml_path(), project_toml.to_string()).await?;
+
+        match dependencies {
+            DependencyType::Regular(deps) => {
+                self.toml.dependencies = Some(
+                    self.toml
+                        .dependencies
+                        .take()
+                        .unwrap_or_default()
+                        .into_iter()
+                        .chain(deps.iter().cloned().map(|dep| dep.into()))
+                        .collect(),
+                )
+            }
+            DependencyType::Build(deps) => {
+                self.toml.build_dependencies = Some(
+                    self.toml
+                        .build_dependencies
+                        .take()
+                        .unwrap_or_default()
+                        .into_iter()
+                        .chain(deps.iter().cloned().map(|dep| dep.into()))
+                        .collect(),
+                )
+            }
+            DependencyType::Test(deps) => {
+                self.toml.test_dependencies = Some(
+                    self.toml
+                        .test_dependencies
+                        .take()
+                        .unwrap_or_default()
+                        .into_iter()
+                        .chain(deps.iter().cloned().map(|dep| dep.into()))
+                        .collect(),
+                )
+            }
+            DependencyType::External(deps) => {
+                self.toml.external_dependencies = Some(
+                    self.toml
+                        .external_dependencies
+                        .take()
+                        .unwrap_or_default()
+                        .into_iter()
+                        .chain(deps)
+                        .collect(),
+                )
+            }
+        };
 
         Ok(())
     }
@@ -443,11 +482,6 @@ impl Project {
                 }
             }
         }
-
-        let toml_content = project_toml.to_string();
-        tokio::fs::write(self.toml_path(), &toml_content).await?;
-        self.toml = PartialProjectToml::new(&toml_content, self.root.clone())?;
-
         Ok(())
     }
 
@@ -486,9 +520,54 @@ impl Project {
             }
         };
 
-        let toml_content = project_toml.to_string();
-        tokio::fs::write(self.toml_path(), &toml_content).await?;
-        self.toml = PartialProjectToml::new(&toml_content, self.root.clone())?;
+        tokio::fs::write(self.toml_path(), project_toml.to_string()).await?;
+
+        match dependencies {
+            DependencyType::Regular(deps) => {
+                self.toml.dependencies = Some(
+                    self.toml
+                        .dependencies
+                        .take()
+                        .unwrap_or_default()
+                        .into_iter()
+                        .filter(|dep| !&deps.iter().any(|d| d == dep.name()))
+                        .collect(),
+                )
+            }
+            DependencyType::Build(deps) => {
+                self.toml.build_dependencies = Some(
+                    self.toml
+                        .build_dependencies
+                        .take()
+                        .unwrap_or_default()
+                        .into_iter()
+                        .filter(|dep| !&deps.iter().any(|d| d == dep.name()))
+                        .collect(),
+                )
+            }
+            DependencyType::Test(deps) => {
+                self.toml.test_dependencies = Some(
+                    self.toml
+                        .test_dependencies
+                        .take()
+                        .unwrap_or_default()
+                        .into_iter()
+                        .filter(|dep| !&deps.iter().any(|d| d == dep.name()))
+                        .collect(),
+                )
+            }
+            DependencyType::External(deps) => {
+                self.toml.external_dependencies = Some(
+                    self.toml
+                        .external_dependencies
+                        .take()
+                        .unwrap_or_default()
+                        .into_iter()
+                        .filter(|(dep, _)| !&deps.iter().any(|(d, _)| d == dep))
+                        .collect(),
+                )
+            }
+        };
 
         Ok(())
     }
@@ -522,9 +601,7 @@ impl Project {
             }
         }
 
-        let toml_content = project_toml.to_string();
-        tokio::fs::write(self.toml_path(), &toml_content).await?;
-        self.toml = PartialProjectToml::new(&toml_content, self.root.clone())?;
+        tokio::fs::write(self.toml_path(), project_toml.to_string()).await?;
 
         Ok(())
     }
@@ -644,9 +721,7 @@ impl Project {
             }
         }
 
-        let toml_content = project_toml.to_string();
-        tokio::fs::write(self.toml_path(), &toml_content).await?;
-        self.toml = PartialProjectToml::new(&toml_content, self.root.clone())?;
+        tokio::fs::write(self.toml_path(), project_toml.to_string()).await?;
 
         Ok(())
     }

--- a/lux-lib/src/git/mod.rs
+++ b/lux-lib/src/git/mod.rs
@@ -4,6 +4,7 @@ use mlua::UserData;
 use crate::lua_rockspec::{DisplayAsLuaKV, DisplayLuaKV, DisplayLuaValue};
 
 pub mod shorthand;
+pub mod utils;
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct GitSource {

--- a/lux-lib/src/git/utils.rs
+++ b/lux-lib/src/git/utils.rs
@@ -1,0 +1,112 @@
+use std::io;
+
+use git2::{AutotagOption, FetchOptions, Repository};
+use git_url_parse::GitUrl;
+use itertools::Itertools;
+use tempdir::TempDir;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum GitError {
+    #[error("error creating temporary directory to checkout git repositotory: {0}")]
+    CreateTempDir(io::Error),
+    #[error("error initializing temporary bare git repository to fetch metadata: {0}")]
+    BareRepoInit(git2::Error),
+    #[error("error initializing remote repository '{0}' to fetch metadata: {1}")]
+    RemoteInit(String, git2::Error),
+    #[error("error fetching from remote repository '{0}': {1}")]
+    RemoteFetch(String, git2::Error),
+    #[error("error listing remote refs for '{0}': {1}")]
+    RemoteList(String, git2::Error),
+    #[error("could not determine latest tag or commit sha for {0}")]
+    NoTagOrCommitSha(String),
+}
+
+pub(crate) fn latest_semver_tag_or_commit_sha(url: &GitUrl) -> Result<String, GitError> {
+    match latest_semver_tag(url)? {
+        Some(tag) => Ok(tag),
+        None => latest_commit_sha(url)?.ok_or(GitError::NoTagOrCommitSha(url.to_string())),
+    }
+}
+
+fn latest_semver_tag(url: &GitUrl) -> Result<Option<String>, GitError> {
+    let temp_dir = TempDir::new("lux-git-meta").map_err(GitError::CreateTempDir)?;
+
+    let url_str = url.to_string();
+    let repo = Repository::init_bare(&temp_dir).map_err(GitError::BareRepoInit)?;
+    let mut remote = repo
+        .remote_anonymous(&url_str)
+        .map_err(|err| GitError::RemoteInit(url_str.clone(), err))?;
+    let mut fetch_opts = FetchOptions::new();
+    fetch_opts.download_tags(AutotagOption::All);
+    remote
+        .fetch(&[] as &[&str], Some(&mut fetch_opts), None)
+        .map_err(|err| GitError::RemoteFetch(url_str.clone(), err))?;
+    let refs = remote
+        .list()
+        .map_err(|err| GitError::RemoteList(url_str.clone(), err))?;
+    Ok(refs
+        .iter()
+        .filter_map(|head| {
+            let tag_name = head.name().strip_prefix("refs/tags/")?;
+            let version_str = tag_name.strip_prefix('v').unwrap_or(tag_name);
+            if let Ok(version) = semver::Version::parse(version_str) {
+                Some((tag_name.to_string(), version))
+            } else {
+                None
+            }
+        })
+        .sorted_by(|(_, a), (_, b)| b.cmp(a))
+        .map(|(version_str, _)| version_str)
+        .collect_vec()
+        .first()
+        .cloned())
+}
+
+fn latest_commit_sha(url: &GitUrl) -> Result<Option<String>, GitError> {
+    let temp_dir = TempDir::new("lux-git-meta").map_err(GitError::CreateTempDir)?;
+    let url_str = url.to_string();
+    let repo = Repository::init_bare(&temp_dir).map_err(GitError::BareRepoInit)?;
+    let mut remote = repo
+        .remote_anonymous(&url_str)
+        .map_err(|err| GitError::RemoteInit(url_str.clone(), err))?;
+    let mut fetch_opts = FetchOptions::new();
+    remote
+        .fetch(&[] as &[&str], Some(&mut fetch_opts), None)
+        .map_err(|err| GitError::RemoteFetch(url_str.clone(), err))?;
+    let refs = remote
+        .list()
+        .map_err(|err| GitError::RemoteList(url_str.clone(), err))?;
+    Ok(refs.iter().find_map(|head| match head.name() {
+        "refs/heads/HEAD" => Some(head.oid().to_string()),
+        "refs/heads/main" => Some(head.oid().to_string()),
+        "refs/heads/master" => Some(head.oid().to_string()),
+        _ => None,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_latest_semver_tag() {
+        if std::env::var("LUX_SKIP_IMPURE_TESTS").unwrap_or("0".into()) == "1" {
+            println!("Skipping impure test");
+            return;
+        }
+        let url = "https://github.com/nvim-neorocks/lux.git".parse().unwrap();
+        assert!(latest_semver_tag(&url).unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn test_latest_commit_sha() {
+        if std::env::var("LUX_SKIP_IMPURE_TESTS").unwrap_or("0".into()) == "1" {
+            println!("Skipping impure test");
+            return;
+        }
+        let url = "https://github.com/nvim-neorocks/lux.git".parse().unwrap();
+        assert!(latest_commit_sha(&url).unwrap().is_some());
+    }
+}


### PR DESCRIPTION
Closes #645.

There's no need to implement `lx remove` for git dependencies, as we remove them by name.