### PR TITLE
fix(cli): fields removed on update

### DIFF
--- a/lux-lib/src/project/mod.rs
+++ b/lux-lib/src/project/mod.rs
@@ -517,7 +517,17 @@ impl Project {
                         .latest_version(dep)
                         .expect("unable to query latest version for package")
                         .to_string();
-                    table[dep.to_string()] = toml_edit::value(dep_version_str);
+                    let mut dep_item = table[dep.to_string()].clone();
+                    match dep_item {
+                        Item::Value(_) => {
+                            table[dep.to_string()] = toml_edit::value(dep_version_str);
+                        }
+                        Item::Table(_) => {
+                            dep_item["version".to_string()] = toml_edit::value(dep_version_str);
+                            table[dep.to_string()] = dep_item;
+                        }
+                        _ => {}
+                    }
                 }
             }
         }


### PR DESCRIPTION
Given a dependency like this:

```toml
[dependencies.foo]
version = "1.0.0"
pin = true
```

`lx update --toml` would result in something like this, losing all non-`version` fields:

```toml
[dependencies]
foo = "1.1.0"
```

After this change, it updates it correctly, to

```toml
[dependencies.foo]
version = "1.1.0"
pin = true
```