### PR TITLE
ci: enable impure tests

### DIFF
--- a/.github/workflows/tests-msvc.yml
+++ b/.github/workflows/tests-msvc.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - master
 
-name: Integration tests (Windows/MSVC)
+name: Tests (Windows/MSVC)
 
 jobs:
   test:
@@ -59,4 +59,4 @@ jobs:
           CC_ENABLE_DEBUG_OUTPUT: true
           CFLAGS: "/NOLOGO /MT /O2"
         run: |
-          cargo nextest run --test "*" --no-fail-fast --features vendored-lua
+          cargo nextest run --tests --no-fail-fast --features vendored-lua

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - master
 
-name: Integration tests (Linux/MacOS)
+name: Tests (*nix)
 
 jobs:
   test:
@@ -37,4 +37,6 @@ jobs:
           name: neorocks
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Run tests (Linux/macOS)
-        run: nix develop .#${{ matrix.lua.feature }} --command cargo nextest run --test "*"
+        run: | 
+          nix develop .#${{ matrix.lua.feature }} --command \
+            cargo nextest run --tests --no-fail-fast


### PR DESCRIPTION
We currently don't run all tests in CI, because

-  `LUX_SKIP_IMPURE_TESTS` leads to impure tests being skipped in the nix builds
- Integration tests just run the ones in `src/test/*`

This PR modifies the integration tests to run all tests, including the impure ones.

Closes #600.