### PR TITLE
refactor!: unify `Install` tree operations

### DIFF
--- a/lux-cli/src/check.rs
+++ b/lux-cli/src/check.rs
@@ -13,8 +13,9 @@ pub async fn check(config: Config) -> Result<()> {
     let luacheck =
         PackageInstallSpec::new("luacheck".parse()?, tree::EntryType::Entrypoint).build();
 
-    Install::new(&project.tree(&config)?, &config)
+    Install::new(&config)
         .package(luacheck)
+        .project(&project)?
         .progress(MultiProgress::new_arc())
         .install()
         .await?;

--- a/lux-cli/src/install.rs
+++ b/lux-cli/src/install.rs
@@ -32,8 +32,9 @@ pub async fn install(data: Install, config: Config) -> Result<()> {
     let packages = apply_build_behaviour(data.package_req, pin, data.force, &tree)?;
 
     // TODO(vhyrro): If the tree doesn't exist then error out.
-    operations::Install::new(&tree, &config)
+    operations::Install::new(&config)
         .packages(packages)
+        .tree(tree)
         .progress(MultiProgress::new_arc())
         .install()
         .await?;

--- a/lux-cli/src/pack.rs
+++ b/lux-cli/src/pack.rs
@@ -72,12 +72,13 @@ pub async fn pack(args: Pack, config: Config) -> Result<()> {
                     let temp_dir = TempDir::new("lux-pack")?.into_path();
                     let temp_config = config.with_tree(temp_dir);
                     let tree = temp_config.tree(lua_version.clone())?;
-                    let packages = Install::new(&tree, &temp_config)
+                    let packages = Install::new(&temp_config)
                         .package(
                             PackageInstallSpec::new(package_req, tree::EntryType::Entrypoint)
                                 .build_behaviour(BuildBehaviour::Force)
                                 .build(),
                         )
+                        .tree(tree.clone())
                         .progress(progress)
                         .install()
                         .await?;

--- a/lux-cli/src/uninstall.rs
+++ b/lux-cli/src/uninstall.rs
@@ -143,8 +143,9 @@ Reinstall?
                 .progress(progress.clone())
                 .remove()
                 .await?;
-            operations::Install::new(&tree, &config)
+            operations::Install::new(&config)
                 .packages(reinstall_specs)
+                .tree(tree)
                 .progress(progress)
                 .install()
                 .await?;

--- a/lux-lib/src/operations/exec.rs
+++ b/lux-lib/src/operations/exec.rs
@@ -119,8 +119,10 @@ pub async fn install_command(command: &str, config: &Config) -> Result<(), Insta
         tree::EntryType::Entrypoint,
     )
     .build();
-    Install::new(&config.tree(LuaVersion::from(config)?)?, config)
+    let tree = config.tree(LuaVersion::from(config)?)?;
+    Install::new(config)
         .package(install_spec)
+        .tree(tree)
         .install()
         .await?;
     Ok(())

--- a/lux-lib/tests/install.rs
+++ b/lux-lib/tests/install.rs
@@ -34,8 +34,9 @@ async fn install_git_package() {
         .unwrap();
 
     let tree = config.tree(LuaVersion::from(&config).unwrap()).unwrap();
-    let installed = Install::new(&tree, &config)
+    let installed = Install::new(&config)
         .package(install_spec)
+        .tree(tree)
         .install()
         .await
         .unwrap();


### PR DESCRIPTION
WIP - similar in vain to the `Sync` refator, aiming to limit mistakes that can be made as a result of mismatched trees.