### PR TITLE
ci: disable test that is flaky on windows

### DIFF
--- a/lux-lib/tests/build.rs
+++ b/lux-lib/tests/build.rs
@@ -147,6 +147,11 @@ async fn test_build_rockspec(rockspec_path: PathBuf) {
 
 #[tokio::test]
 async fn treesitter_parser_build() {
+    if cfg!(target_env = "msvc") {
+        println!("Skipping test that is flaky on Windows/MSVC");
+        return;
+    }
+
     let dir = TempDir::new().unwrap();
 
     let content = String::from_utf8(


### PR DESCRIPTION
For some reason, this one is flaky on Windows. The `test_build_multiple_treesitter_parsers` seems to be doing fine.