### PR TITLE
ci(cd): don't build for windows targets

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -68,6 +68,7 @@ jobs:
       - run: echo "RUSTFLAGS=${RUSTFLAGS} -C target-feature=+crt-static" >> "${GITHUB_ENV}"
         if: endsWith(matrix.target, 'windows-msvc')
       - uses: taiki-e/upload-rust-binary-action@v1
+        # TODO: also build `lux-lua`
         with:
           bin: lx
           target: ${{ matrix.target }}

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -35,16 +35,16 @@ jobs:
             os: ubuntu-22.04
           - target: aarch64-apple-darwin
             os: macos-13
-          - target: aarch64-pc-windows-msvc
-            os: windows-2022
+          # - target: aarch64-pc-windows-msvc
+          #   os: windows-2022
+          # - target: x86_64-pc-windows-msvc
+          #   os: windows-2022
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-22.04
           - target: x86_64-unknown-linux-musl
             os: ubuntu-22.04
           - target: x86_64-apple-darwin
             os: macos-13
-          - target: x86_64-pc-windows-msvc
-            os: windows-2022
           - target: x86_64-unknown-freebsd
             os: ubuntu-22.04
     timeout-minutes: 60


### PR DESCRIPTION
This should make the build hopefully succeed now and allow us to vendor valid builds for `cargo binstall`. In the near future, I also want to extend this to building lux-lua so that lux.nvim can also pull it down `blink.cmp` style.