### PR TITLE
fix: remove hash field from `RockSourceInternal`

### DIFF
--- a/lux-lib/src/build/mod.rs
+++ b/lux-lib/src/build/mod.rs
@@ -331,15 +331,6 @@ async fn do_build<R: Rockspec + HasIntegrity>(
         source: source_metadata.hash,
     };
 
-    if let Some(expected) = &rockspec.source().current_platform().integrity {
-        if expected.matches(&hashes.source).is_none() {
-            return Err(BuildError::SourceIntegrityMismatch {
-                expected: expected.clone(),
-                actual: hashes.source,
-            });
-        }
-    }
-
     let mut package = LocalPackage::from(
         &PackageSpec::new(rockspec.package().clone(), rockspec.version().clone()),
         build.constraint,

--- a/lux-lib/src/upload/mod.rs
+++ b/lux-lib/src/upload/mod.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use crate::lua_rockspec::{LocalRockSource, RemoteRockSource, RockSourceSpec};
+use crate::lua_rockspec::{RemoteRockSource, RockSourceSpec};
 use crate::package::PackageVersion;
 use crate::project::project_toml::RemoteProjectTomlValidationError;
 use crate::rockspec::Rockspec;
@@ -389,13 +389,6 @@ mod helpers {
     ) -> Result<(), NonDeterministicGitSourceError> {
         match source {
             RemoteRockSource {
-                local:
-                    LocalRockSource {
-                        integrity: Some(_), ..
-                    },
-                source_spec: RockSourceSpec::Git(_),
-            } => {}
-            RemoteRockSource {
                 source_spec:
                     RockSourceSpec::Git(GitSource {
                         checkout_ref: Some(_),
@@ -443,26 +436,6 @@ mod tests {
             .unwrap();
 
         helpers::verify_rockspec_determinism(rockspec.source().current_platform()).unwrap_err();
-
-        let rockspec_content = r#"
-            package = "test-package"
-            version = "1.0.0"
-            lua = ">=5.1"
-
-            [source]
-            url = "git+https://exaple.com/repo.git"
-            hash = "sha256-1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
-
-            [build]
-            type = "builtin"
-        "#;
-
-        let rockspec = PartialProjectToml::new(rockspec_content, ProjectRoot::default())
-            .unwrap()
-            .into_remote()
-            .unwrap();
-
-        helpers::verify_rockspec_determinism(rockspec.source().current_platform()).unwrap();
 
         let rockspec_content = r#"
             package = "test-package"


### PR DESCRIPTION
Back when I implemented this, I wasn't aware that luarocks would error if the source table has any fields it doesn't know about.