### PR TITLE
fix: unable to parse large luarocks manifest

### DIFF
--- a/lux-cli/Cargo.toml
+++ b/lux-cli/Cargo.toml
@@ -58,7 +58,7 @@ path = "../lux-lib/"
 features = ["clap"]
 
 [features]
-default = ["luajit"]
+default = ["lua54", "vendored-lua"]
 lua51 = ["lux-lib/lua51"]
 lua52 = ["lux-lib/lua52"]
 lua53 = ["lux-lib/lua53"]

--- a/lux-lib/Cargo.toml
+++ b/lux-lib/Cargo.toml
@@ -96,7 +96,7 @@ assert_fs = "1.1.3"
 predicates = "3.1.3"
 
 [features]
-default = ["luajit"]
+default = ["lua54", "vendored-lua"]
 clap = ["dep:clap"]
 lua = []
 lua51 = ["mlua/lua51"]

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -43,7 +43,7 @@
       pname = "lux";
       version = "0.1.0";
       src = cleanCargoSrc;
-      buildInputs = commonArgs.buildInputs ++ [final.luajit];
+      buildInputs = commonArgs.buildInputs ++ [final.lua5_4];
     });
 
   individualCrateArgs =
@@ -108,7 +108,7 @@
         inherit (luxCliCargo) pname version;
         inherit buildType;
 
-        buildInputs = individualCrateArgs.buildInputs ++ [final.luajit];
+        buildInputs = individualCrateArgs.buildInputs ++ [final.lua5_4];
 
         cargoExtraArgs = "-p ${luxCliCargo.pname}";
 
@@ -171,7 +171,7 @@ in {
       inherit (luxCliCargo) pname version;
       src = self;
 
-      buildInputs = commonArgs.buildInputs ++ [final.luajit];
+      buildInputs = commonArgs.buildInputs ++ [final.lua5_4];
 
       nativeCheckInputs = with final; [
         cacert
@@ -233,7 +233,7 @@ in {
     // {
       inherit (luxCliCargo) pname version;
       src = cleanCargoSrc;
-      buildInputs = commonArgs.buildInputs ++ [final.luajit];
+      buildInputs = commonArgs.buildInputs ++ [final.lua5_4];
       cargoArtifacts = lux-deps;
       cargoClippyExtraArgs = "--all-targets -- --deny warnings";
     });


### PR DESCRIPTION
Fixes #725.

We build Lux with luajit and #725 is a luajit limitation.
Solution: Build Lux with Lua 5.4.

@vhyrro fyi, in lux.nvim, we'll have to use lux-lua built against Lua 5.1 (not luajit) if we want to prevent it from running into that issue.
(We should do that anyway, as not all Neovim builds ship with luajit).

I've also enabled the `vendored-lua` feature by default, so that we can build lux and run tests in a devShell with a different lua version.