### PR TITLE
fix!: more robust lua binary detection

### DIFF
--- a/lux-lib/src/build/utils.rs
+++ b/lux-lib/src/build/utils.rs
@@ -452,10 +452,13 @@ pub enum InstallBinaryError {
 }
 
 #[derive(Debug, Error)]
-#[error(transparent)]
 pub enum WrapBinaryError {
+    #[error(transparent)]
     Io(#[from] io::Error),
+    #[error(transparent)]
     Utf8(#[from] FromUtf8Error),
+    #[error("no `lua` executable found")]
+    NoLuaBinary,
 }
 
 /// Returns the file path of the installed binary
@@ -499,7 +502,9 @@ async fn install_wrapped_binary(
     #[cfg(target_family = "windows")]
     let target = tree.bin().join(format!("{}.bat", target));
 
-    let lua_bin = lua.lua_binary(config).unwrap_or("lua".into());
+    let lua_bin = lua
+        .lua_binary_or_config_override(config)
+        .ok_or(WrapBinaryError::NoLuaBinary)?;
 
     #[cfg(target_family = "unix")]
     let content = format!(
@@ -543,19 +548,22 @@ async fn set_executable_permissions(script: &Path) -> std::io::Result<()> {
 /// If a script is mistaken for a Lua script, package authors can disable
 /// wrapping with the `deploy.wrap_bin_scripts` rockspec config.
 async fn is_compatible_lua_script(file: &Path, lua: &LuaInstallation, config: &Config) -> bool {
-    let lua_bin = lua.lua_binary(config).unwrap_or("lua".into());
-    Command::new(lua_bin)
-        .arg("-e")
-        .arg(format!(
-            "if loadfile('{}') then os.exit(0) else os.exit(1) end",
-            // On Windows, Lua escapes path separators, so we ensure forward slashes
-            file.to_slash_lossy()
-        ))
-        .stderr(Stdio::null())
-        .stdout(Stdio::null())
-        .status()
-        .await
-        .is_ok_and(|status| status.success())
+    if let Some(lua_bin) = lua.lua_binary_or_config_override(config) {
+        Command::new(lua_bin)
+            .arg("-e")
+            .arg(format!(
+                "if loadfile('{}') then os.exit(0) else os.exit(1) end",
+                // On Windows, Lua escapes path separators, so we ensure forward slashes
+                file.to_slash_lossy()
+            ))
+            .stderr(Stdio::null())
+            .stdout(Stdio::null())
+            .status()
+            .await
+            .is_ok_and(|status| status.success())
+    } else {
+        false
+    }
 }
 
 pub(crate) fn substitute_variables(

--- a/lux-lib/src/config/mod.rs
+++ b/lux-lib/src/config/mod.rs
@@ -10,7 +10,6 @@ use thiserror::Error;
 use tree::RockLayoutConfig;
 use url::Url;
 
-use crate::operations::LuaBinary;
 use crate::tree::{Tree, TreeError};
 use crate::{
     build::{utils, variables::HasVariables},
@@ -101,6 +100,10 @@ impl LuaVersion {
         } else {
             Err(LuaVersionError::UnsupportedLuaVersion(version))
         }
+    }
+
+    pub(crate) fn is_luajit(&self) -> bool {
+        matches!(self, Self::LuaJIT | Self::LuaJIT52)
     }
 }
 
@@ -443,13 +446,10 @@ impl ConfigBuilder {
         let cache_dir = self.cache_dir.unwrap_or(Config::get_default_cache_path()?);
         let user_tree = self.user_tree.unwrap_or(data_dir.join("tree"));
 
-        let lua_version =
-            self.lua_version
-                .or(crate::lua_installation::detect_installed_lua_version_sync(
-                    LuaBinary::default(),
-                )
-                .ok()
-                .and_then(|version| LuaVersion::from_version(version).ok()));
+        let lua_version = self
+            .lua_version
+            .or(crate::lua_installation::detect_installed_lua_version());
+
         Ok(Config {
             enable_development_packages: self.enable_development_packages.unwrap_or(false),
             server: self

--- a/lux-lib/src/lua_installation/mod.rs
+++ b/lux-lib/src/lua_installation/mod.rs
@@ -1,18 +1,20 @@
 use is_executable::IsExecutable;
 use itertools::Itertools;
 use path_slash::PathBufExt;
+use std::fmt;
+use std::fmt::Display;
 use std::io;
 use std::path::Path;
 use std::path::PathBuf;
 use target_lexicon::Triple;
 use thiserror::Error;
-use tokio::process::Command;
+use which::which;
 
 use crate::build::external_dependency::to_lib_name;
 use crate::build::external_dependency::ExternalDependencyInfo;
 use crate::build::utils::{c_lib_extension, format_path};
+use crate::config::external_deps::ExternalDependencySearchConfig;
 use crate::lua_rockspec::ExternalDependencySpec;
-use crate::operations::{LuaBinary, LuaBinaryError};
 use crate::project::Project;
 use crate::{
     build::variables::HasVariables,
@@ -24,45 +26,47 @@ pub struct LuaInstallation {
     pub version: LuaVersion,
     dependency_info: ExternalDependencyInfo,
     /// Binary to the Lua executable, if present
-    bin: Option<PathBuf>,
+    pub(crate) bin: Option<PathBuf>,
+}
+
+#[derive(Debug, Error)]
+pub enum LuaBinaryError {
+    #[error("neither `lua` nor `luajit` found on the PATH")]
+    LuaBinaryNotFound,
+    #[error(transparent)]
+    DetectLuaVersion(#[from] DetectLuaVersionError),
+    #[error(
+        "{} -v (= {}) does not match expected Lua version {}",
+        lua_cmd,
+        installed_version,
+        lua_version
+    )]
+    LuaVersionMismatch {
+        lua_cmd: String,
+        installed_version: PackageVersion,
+        lua_version: LuaVersion,
+    },
+    #[error("{0} not found on the PATH")]
+    CustomBinaryNotFound(String),
+}
+
+#[derive(Error, Debug)]
+pub enum DetectLuaVersionError {
+    #[error("failed to run {0}: {1}")]
+    RunLuaCommand(String, io::Error),
+    #[error("failed to parse Lua version from output: {0}")]
+    ParseLuaVersion(String),
+    #[error(transparent)]
+    PackageVersionParse(#[from] crate::package::PackageVersionParseError),
+    #[error(transparent)]
+    LuaVersion(#[from] crate::config::LuaVersionError),
 }
 
 impl LuaInstallation {
     pub fn new(version: &LuaVersion, config: &Config) -> Self {
-        let pkg_name = match version {
-            LuaVersion::Lua51 => "lua5.1",
-            LuaVersion::Lua52 => "lua5.2",
-            LuaVersion::Lua53 => "lua5.3",
-            LuaVersion::Lua54 => "lua5.4",
-            LuaVersion::LuaJIT | LuaVersion::LuaJIT52 => "luajit",
-        };
-
-        let mut dependency_info = ExternalDependencyInfo::probe(
-            pkg_name,
-            &ExternalDependencySpec::default(),
-            config.external_deps(),
-        );
-
-        if let Ok(info) = &mut dependency_info {
-            let bin = info.lib_dir.as_ref().and_then(|lib_dir| {
-                lib_dir
-                    .parent()
-                    .map(|parent| parent.join("bin"))
-                    .filter(|dir| dir.is_dir())
-                    .and_then(|bin_path| find_lua_executable(&bin_path))
-            });
-            let lua_lib_name = info
-                .lib_dir
-                .as_ref()
-                .and_then(|lib_dir| get_lua_lib_name(lib_dir, version));
-            info.lib_name = lua_lib_name;
-            return Self {
-                version: version.clone(),
-                dependency_info: dependency_info.unwrap(),
-                bin,
-            };
+        if let Some(lua_intallation) = Self::probe(version, config.external_deps()) {
+            return lua_intallation;
         }
-
         let output = Self::root_dir(version, config);
         if output.join("include").is_dir() {
             let bin_dir = Some(output.join("bin")).filter(|bin_path| bin_path.is_dir());
@@ -85,6 +89,47 @@ impl LuaInstallation {
             }
         } else {
             Self::install(version, config)
+        }
+    }
+
+    pub(crate) fn probe(
+        version: &LuaVersion,
+        search_config: &ExternalDependencySearchConfig,
+    ) -> Option<Self> {
+        let pkg_name = match version {
+            LuaVersion::Lua51 => "lua5.1",
+            LuaVersion::Lua52 => "lua5.2",
+            LuaVersion::Lua53 => "lua5.3",
+            LuaVersion::Lua54 => "lua5.4",
+            LuaVersion::LuaJIT | LuaVersion::LuaJIT52 => "luajit",
+        };
+
+        let mut dependency_info = ExternalDependencyInfo::probe(
+            pkg_name,
+            &ExternalDependencySpec::default(),
+            search_config,
+        );
+
+        if let Ok(info) = &mut dependency_info {
+            let bin = info.lib_dir.as_ref().and_then(|lib_dir| {
+                lib_dir
+                    .parent()
+                    .map(|parent| parent.join("bin"))
+                    .filter(|dir| dir.is_dir())
+                    .and_then(|bin_path| find_lua_executable(&bin_path))
+            });
+            let lua_lib_name = info
+                .lib_dir
+                .as_ref()
+                .and_then(|lib_dir| get_lua_lib_name(lib_dir, version));
+            info.lib_name = lua_lib_name;
+            Some(Self {
+                version: version.clone(),
+                dependency_info: dependency_info.unwrap(),
+                bin,
+            })
+        } else {
+            None
         }
     }
 
@@ -191,11 +236,11 @@ impl LuaInstallation {
 
     /// Get the Lua binary (if present), prioritising
     /// a potentially overridden value in the config.
-    pub(crate) fn lua_binary(&self, config: &Config) -> Option<String> {
+    pub(crate) fn lua_binary_or_config_override(&self, config: &Config) -> Option<String> {
         config.variables().get("LUA").cloned().or(self
             .bin
             .clone()
-            .or(LuaBinary::default().try_into().ok())
+            .or(LuaBinary::new(self.version.clone(), config).try_into().ok())
             .map(|bin| bin.to_slash_lossy().to_string()))
     }
 }
@@ -220,7 +265,11 @@ impl HasVariables for LuaInstallation {
             "LUA" => self
                 .bin
                 .clone()
-                .or(LuaBinary::default().try_into().ok())
+                .or(LuaBinary::Lua {
+                    lua_version: self.version.clone(),
+                }
+                .try_into()
+                .ok())
                 .map(|lua| format_path(&lua)),
             "LUALIB" => self.lua_lib().or(Some("".into())),
             _ => None,
@@ -229,75 +278,94 @@ impl HasVariables for LuaInstallation {
     }
 }
 
-#[derive(Error, Debug)]
-pub enum DetectLuaVersionError {
-    #[error("error detecting Lua version: {0}")]
-    LuaBinary(#[from] LuaBinaryError),
-    #[error("failed to run {0}: {1}")]
-    RunLuaCommand(String, io::Error),
-    #[error("failed to parse Lua version from output: {0}")]
-    ParseLuaVersion(String),
-    #[error(transparent)]
-    PackageVersionParse(#[from] crate::package::PackageVersionParseError),
-    #[error(transparent)]
-    LuaVersion(#[from] crate::config::LuaVersionError),
+#[derive(Clone)]
+pub enum LuaBinary {
+    /// The regular Lua interpreter.
+    Lua { lua_version: LuaVersion },
+    /// Custom Lua interpreter.
+    Custom(String),
 }
 
-pub async fn detect_installed_lua_version(
-    lua: LuaBinary,
-) -> Result<PackageVersion, DetectLuaVersionError> {
-    let lua_cmd: PathBuf = lua.try_into()?;
-    let output = match Command::new(&lua_cmd).arg("-v").output().await {
-        Ok(output) => Ok(output),
-        Err(err) => Err(DetectLuaVersionError::RunLuaCommand(
-            lua_cmd.to_string_lossy().to_string(),
-            err,
-        )),
-    }?;
-    let output_vec = if output.stderr.is_empty() {
-        output.stdout
-    } else {
-        // Yes, Lua 5.1 prints to stderr (-‸ლ)
-        output.stderr
-    };
-    let lua_output = String::from_utf8_lossy(&output_vec).to_string();
-    parse_lua_version_from_output(&lua_output)
+impl Display for LuaBinary {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            LuaBinary::Lua { lua_version } => write!(f, "lua {lua_version}"),
+            LuaBinary::Custom(cmd) => write!(f, "{cmd}"),
+        }
+    }
 }
 
-pub fn detect_installed_lua_version_sync(
-    lua: LuaBinary,
-) -> Result<PackageVersion, DetectLuaVersionError> {
-    let lua_cmd: PathBuf = lua.try_into()?;
-    let output = match std::process::Command::new(&lua_cmd).arg("-v").output() {
-        Ok(output) => Ok(output),
-        Err(err) => Err(DetectLuaVersionError::RunLuaCommand(
-            lua_cmd.to_string_lossy().to_string(),
-            err,
-        )),
-    }?;
-    let output_vec = if output.stderr.is_empty() {
-        output.stdout
-    } else {
-        // Yes, Lua 5.1 prints to stderr (-‸ლ)
-        output.stderr
-    };
-    let lua_output = String::from_utf8_lossy(&output_vec).to_string();
-    parse_lua_version_from_output(&lua_output)
+impl LuaBinary {
+    /// Construct a new `LuaBinary` for the given `LuaVersion`,
+    /// potentially prioritising an overridden value in the config.
+    pub fn new(lua_version: LuaVersion, config: &Config) -> Self {
+        match config.variables().get("LUA").cloned() {
+            Some(lua) => Self::Custom(lua),
+            None => Self::Lua { lua_version },
+        }
+    }
 }
 
-fn parse_lua_version_from_output(
-    lua_output: &str,
-) -> Result<PackageVersion, DetectLuaVersionError> {
-    let lua_version_str = lua_output
-        .trim_start_matches("Lua")
-        .trim_start_matches("JIT")
-        .split_whitespace()
-        .next()
-        .map(|s| s.to_string())
-        .ok_or(DetectLuaVersionError::ParseLuaVersion(
-            lua_output.to_string(),
-        ))?;
-    Ok(PackageVersion::parse(&lua_version_str)?)
+impl From<PathBuf> for LuaBinary {
+    fn from(value: PathBuf) -> Self {
+        Self::Custom(value.to_string_lossy().to_string())
+    }
+}
+
+impl TryFrom<LuaBinary> for PathBuf {
+    type Error = LuaBinaryError;
+
+    fn try_from(value: LuaBinary) -> Result<Self, Self::Error> {
+        match value {
+            LuaBinary::Lua { lua_version } => {
+                if let Some(lua_binary) =
+                    LuaInstallation::probe(&lua_version, &ExternalDependencySearchConfig::default())
+                        .and_then(|lua_installation| lua_installation.bin)
+                {
+                    return Ok(lua_binary);
+                }
+                if lua_version.is_luajit() {
+                    if let Ok(path) = which("luajit") {
+                        return Ok(path);
+                    }
+                }
+                match which("lua") {
+                    Ok(path) => {
+                        let installed_version = detect_installed_lua_version_from_path(&path)?;
+                        if lua_version
+                            .clone()
+                            .as_version_req()
+                            .matches(&installed_version)
+                        {
+                            Ok(path)
+                        } else {
+                            Err(Self::Error::LuaVersionMismatch {
+                                lua_cmd: path.to_slash_lossy().to_string(),
+                                installed_version,
+                                lua_version,
+                            })?
+                        }
+                    }
+                    Err(_) => Err(LuaBinaryError::LuaBinaryNotFound),
+                }
+            }
+            LuaBinary::Custom(bin) => match which(&bin) {
+                Ok(path) => Ok(path),
+                Err(_) => Err(LuaBinaryError::CustomBinaryNotFound(bin)),
+            },
+        }
+    }
+}
+
+pub fn detect_installed_lua_version() -> Option<LuaVersion> {
+    which("lua")
+        .ok()
+        .or(which("luajit").ok())
+        .and_then(|lua_cmd| {
+            detect_installed_lua_version_from_path(&lua_cmd)
+                .ok()
+                .and_then(|version| LuaVersion::from_version(version).ok())
+        })
 }
 
 fn find_lua_executable(bin_path: &Path) -> Option<PathBuf> {
@@ -355,6 +423,41 @@ fn get_lua_lib_name(lib_dir: &Path, lua_version: &LuaVersion) -> Option<String> 
         .map(|file| to_lib_name(&file))
 }
 
+fn detect_installed_lua_version_from_path(
+    lua_cmd: &Path,
+) -> Result<PackageVersion, DetectLuaVersionError> {
+    let output = match std::process::Command::new(lua_cmd).arg("-v").output() {
+        Ok(output) => Ok(output),
+        Err(err) => Err(DetectLuaVersionError::RunLuaCommand(
+            lua_cmd.to_string_lossy().to_string(),
+            err,
+        )),
+    }?;
+    let output_vec = if output.stderr.is_empty() {
+        output.stdout
+    } else {
+        // Yes, Lua 5.1 prints to stderr (-‸ლ)
+        output.stderr
+    };
+    let lua_output = String::from_utf8_lossy(&output_vec).to_string();
+    parse_lua_version_from_output(&lua_output)
+}
+
+fn parse_lua_version_from_output(
+    lua_output: &str,
+) -> Result<PackageVersion, DetectLuaVersionError> {
+    let lua_version_str = lua_output
+        .trim_start_matches("Lua")
+        .trim_start_matches("JIT")
+        .split_whitespace()
+        .next()
+        .map(|s| s.to_string())
+        .ok_or(DetectLuaVersionError::ParseLuaVersion(
+            lua_output.to_string(),
+        ))?;
+    Ok(PackageVersion::parse(&lua_version_str)?)
+}
+
 #[cfg(test)]
 mod test {
     use crate::config::ConfigBuilder;
@@ -385,9 +488,9 @@ mod test {
         let lua_installation = LuaInstallation::new(lua_version, &config);
         // FIXME: This fails when run in the nix checkPhase
         assert!(lua_installation.bin.is_some());
-        let pkg_version = detect_installed_lua_version(lua_installation.bin.unwrap().into())
-            .await
-            .unwrap();
+        let lua_binary: LuaBinary = lua_installation.bin.unwrap().into();
+        let lua_bin_path: PathBuf = lua_binary.try_into().unwrap();
+        let pkg_version = detect_installed_lua_version_from_path(&lua_bin_path).unwrap();
         assert_eq!(&LuaVersion::from_version(pkg_version).unwrap(), lua_version);
     }
 

--- a/lux-lib/src/operations/run.rs
+++ b/lux-lib/src/operations/run.rs
@@ -8,13 +8,14 @@ use tokio::process::Command;
 
 use crate::{
     config::Config,
+    lua_installation::LuaBinary,
     lua_rockspec::LuaVersionError,
     operations,
     path::{Paths, PathsError},
     project::{project_toml::LocalProjectTomlValidationError, Project, ProjectTreeError},
 };
 
-use super::{LuaBinary, RunLuaError};
+use super::RunLuaError;
 
 #[derive(Debug, Error)]
 #[error("`{0}` should not be used as a `command` as it is not cross-platform.
@@ -81,8 +82,7 @@ async fn run_with_local_lua(
     operations::run_lua(
         project.root(),
         &project.tree(config)?,
-        version,
-        LuaBinary::Lua,
+        LuaBinary::new(version, config),
         &args.into_iter().cloned().collect(),
     )
     .await?;

--- a/lux-lib/src/operations/run_lua.rs
+++ b/lux-lib/src/operations/run_lua.rs
@@ -3,88 +3,23 @@
 //! The interfaces exposed here ensure that the correct version of Lua is being used.
 
 use std::{
-    fmt, io,
+    io,
     path::{Path, PathBuf},
 };
 
 use thiserror::Error;
 use tokio::process::Command;
-use which::which;
 
 use crate::{
-    config::LuaVersion,
-    lua_installation,
+    lua_installation::{LuaBinary, LuaBinaryError},
     path::{Paths, PathsError},
     tree::Tree,
 };
-
-#[derive(Clone, Default)]
-pub enum LuaBinary {
-    /// The regular Lua interpreter.
-    #[default]
-    Lua,
-    /// Custom Lua interpreter.
-    Custom(String),
-}
-
-#[derive(Debug, Error)]
-pub enum LuaBinaryError {
-    #[error("neither `lua` nor `luajit` found on the PATH")]
-    LuaBinaryNotFound,
-    #[error("{0} not found on the PATH")]
-    CustomBinaryNotFound(String),
-}
-
-impl fmt::Display for LuaBinary {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            LuaBinary::Lua => write!(f, "lua"),
-            LuaBinary::Custom(cmd) => write!(f, "{cmd}"),
-        }
-    }
-}
-
-impl From<PathBuf> for LuaBinary {
-    fn from(value: PathBuf) -> Self {
-        Self::Custom(value.to_string_lossy().to_string())
-    }
-}
-
-impl TryFrom<LuaBinary> for PathBuf {
-    type Error = LuaBinaryError;
-
-    fn try_from(value: LuaBinary) -> Result<Self, Self::Error> {
-        match value {
-            LuaBinary::Lua => match which("lua") {
-                Ok(path) => Ok(path),
-                Err(_) => match which("luajit") {
-                    Ok(path) => Ok(path),
-                    Err(_) => Err(LuaBinaryError::LuaBinaryNotFound),
-                },
-            },
-            LuaBinary::Custom(bin) => match which(&bin) {
-                Ok(path) => Ok(path),
-                Err(_) => Err(LuaBinaryError::CustomBinaryNotFound(bin)),
-            },
-        }
-    }
-}
 
 #[derive(Error, Debug)]
 pub enum RunLuaError {
     #[error("error running lua: {0}")]
     LuaBinary(#[from] LuaBinaryError),
-    #[error(
-        "{} -v (= {}) does not match expected Lua version {}",
-        lua_cmd,
-        installed_version,
-        lua_version
-    )]
-    LuaVersionMismatch {
-        lua_cmd: String,
-        installed_version: LuaVersion,
-        lua_version: LuaVersion,
-    },
     #[error("failed to run {lua_cmd}: {source}")]
     LuaCommandFailed {
         lua_cmd: String,
@@ -103,33 +38,10 @@ pub enum RunLuaError {
 pub async fn run_lua(
     root: &Path,
     tree: &Tree,
-    expected_version: LuaVersion,
     lua_cmd: LuaBinary,
     args: &Vec<String>,
 ) -> Result<(), RunLuaError> {
     let paths = Paths::new(tree)?;
-
-    match lua_installation::detect_installed_lua_version(lua_cmd.clone())
-        .await
-        .and_then(|ver| Ok(LuaVersion::from_version(ver)?))
-    {
-        Ok(installed_version) if installed_version != expected_version => {
-            Err(RunLuaError::LuaVersionMismatch {
-                lua_cmd: lua_cmd.to_string(),
-                installed_version,
-                lua_version: expected_version,
-            })?
-        }
-        Ok(_) => {}
-        Err(_) => {
-            eprintln!(
-                "⚠️ WARNING: could not parse lua version from '{} -v' output.
-Cannot verify that the expected version is being used.
-                ",
-                &lua_cmd
-            );
-        }
-    }
 
     let lua_cmd: PathBuf = lua_cmd.try_into()?;
 

--- a/lux-lib/tests/build.rs
+++ b/lux-lib/tests/build.rs
@@ -5,9 +5,8 @@ use assert_fs::TempDir;
 use lux_lib::{
     build::{Build, BuildBehaviour::Force},
     config::{ConfigBuilder, LuaVersion},
-    lua_installation::{detect_installed_lua_version, detect_installed_lua_version_sync},
+    lua_installation::detect_installed_lua_version,
     lua_rockspec::RemoteLuaRockspec,
-    operations::LuaBinary,
     progress::{MultiProgress, Progress},
     project::Project,
     tree,
@@ -23,11 +22,7 @@ async fn builtin_build() {
             .unwrap();
     let rockspec = RemoteLuaRockspec::new(&content).unwrap();
 
-    let lua_version = detect_installed_lua_version(LuaBinary::default())
-        .await
-        .ok()
-        .and_then(|version| LuaVersion::from_version(version).ok())
-        .or(Some(LuaVersion::Lua51));
+    let lua_version = detect_installed_lua_version().or(Some(LuaVersion::Lua51));
 
     let config = ConfigBuilder::new()
         .unwrap()
@@ -66,11 +61,7 @@ async fn make_build() {
     .unwrap();
     let rockspec = RemoteLuaRockspec::new(&content).unwrap();
 
-    let lua_version = detect_installed_lua_version(LuaBinary::default())
-        .await
-        .ok()
-        .and_then(|version| LuaVersion::from_version(version).ok())
-        .or(Some(LuaVersion::Lua51));
+    let lua_version = detect_installed_lua_version().or(Some(LuaVersion::Lua51));
 
     let config = ConfigBuilder::new()
         .unwrap()
@@ -123,11 +114,7 @@ async fn test_build_rockspec(rockspec_path: PathBuf) {
     let content = String::from_utf8(std::fs::read(rockspec_path).unwrap()).unwrap();
     let rockspec = RemoteLuaRockspec::new(&content).unwrap();
 
-    let lua_version = detect_installed_lua_version(LuaBinary::default())
-        .await
-        .ok()
-        .and_then(|version| LuaVersion::from_version(version).ok())
-        .or(Some(LuaVersion::Lua51));
+    let lua_version = detect_installed_lua_version().or(Some(LuaVersion::Lua51));
 
     let config = ConfigBuilder::new()
         .unwrap()
@@ -171,11 +158,7 @@ async fn treesitter_parser_build() {
     .unwrap();
     let rockspec = RemoteLuaRockspec::new(&content).unwrap();
 
-    let lua_version = detect_installed_lua_version(LuaBinary::default())
-        .await
-        .ok()
-        .and_then(|version| LuaVersion::from_version(version).ok())
-        .or(Some(LuaVersion::Lua51));
+    let lua_version = detect_installed_lua_version().or(Some(LuaVersion::Lua51));
 
     let config = ConfigBuilder::new()
         .unwrap()
@@ -213,11 +196,7 @@ async fn test_build_local_project_no_source() {
     let project = Project::from(&project_root).unwrap().unwrap();
     let project_toml = project.toml().into_local().unwrap();
 
-    let lua_version = detect_installed_lua_version(LuaBinary::default())
-        .await
-        .ok()
-        .and_then(|version| LuaVersion::from_version(version).ok())
-        .or(Some(LuaVersion::Lua51));
+    let lua_version = detect_installed_lua_version().or(Some(LuaVersion::Lua51));
 
     let config = ConfigBuilder::new()
         .unwrap()
@@ -251,11 +230,7 @@ async fn test_build_local_project_only_src() {
     let project = Project::from(&project_root).unwrap().unwrap();
     let project_toml = project.toml().into_local().unwrap();
 
-    let lua_version = detect_installed_lua_version(LuaBinary::default())
-        .await
-        .ok()
-        .and_then(|version| LuaVersion::from_version(version).ok())
-        .or(Some(LuaVersion::Lua51));
+    let lua_version = detect_installed_lua_version().or(Some(LuaVersion::Lua51));
 
     let config = ConfigBuilder::new()
         .unwrap()
@@ -295,10 +270,7 @@ fn test_build_multiple_treesitter_parsers() {
     .unwrap();
     let rockspec = RemoteLuaRockspec::new(&content).unwrap();
 
-    let lua_version = detect_installed_lua_version_sync(LuaBinary::default())
-        .ok()
-        .and_then(|version| LuaVersion::from_version(version).ok())
-        .or(Some(LuaVersion::Lua51));
+    let lua_version = detect_installed_lua_version().or(Some(LuaVersion::Lua51));
 
     let runtime = Builder::new_multi_thread()
         .worker_threads(4)
@@ -351,11 +323,7 @@ async fn build_project_with_git_dependency() {
     let project = Project::from(&project_root).unwrap().unwrap();
     let project_toml = project.toml().into_local().unwrap();
 
-    let lua_version = detect_installed_lua_version(LuaBinary::default())
-        .await
-        .ok()
-        .and_then(|version| LuaVersion::from_version(version).ok())
-        .or(Some(LuaVersion::Lua51));
+    let lua_version = detect_installed_lua_version().or(Some(LuaVersion::Lua51));
 
     let config = ConfigBuilder::new()
         .unwrap()

--- a/lux-lib/tests/exec.rs
+++ b/lux-lib/tests/exec.rs
@@ -9,17 +9,11 @@ use tempdir::TempDir;
 #[cfg(not(target_env = "msvc"))]
 #[tokio::test]
 async fn run_nlua() {
-    use lux_lib::{
-        config::LuaVersion, lua_installation::detect_installed_lua_version, operations::LuaBinary,
-    };
+    use lux_lib::{config::LuaVersion, lua_installation::detect_installed_lua_version};
 
     let dir = TempDir::new("lux-test").unwrap();
 
-    let lua_version = detect_installed_lua_version(LuaBinary::default())
-        .await
-        .ok()
-        .and_then(|version| LuaVersion::from_version(version).ok())
-        .or(Some(LuaVersion::Lua51));
+    let lua_version = detect_installed_lua_version().or(Some(LuaVersion::Lua51));
 
     let config = ConfigBuilder::new()
         .unwrap()

--- a/lux-lib/tests/install.rs
+++ b/lux-lib/tests/install.rs
@@ -4,7 +4,7 @@ use lux_lib::{
     git::GitSource,
     lua_installation::detect_installed_lua_version,
     lua_rockspec::RockSourceSpec,
-    operations::{Install, LuaBinary, PackageInstallSpec},
+    operations::{Install, PackageInstallSpec},
     tree::EntryType,
 };
 
@@ -33,11 +33,7 @@ async fn install_http_package() {
 
 async fn test_install(install_spec: PackageInstallSpec) {
     let dir = TempDir::new().unwrap();
-    let lua_version = detect_installed_lua_version(LuaBinary::default())
-        .await
-        .ok()
-        .and_then(|version| LuaVersion::from_version(version).ok())
-        .or(Some(LuaVersion::Lua51));
+    let lua_version = detect_installed_lua_version().or(Some(LuaVersion::Lua51));
 
     let config = ConfigBuilder::new()
         .unwrap()

--- a/lux-lib/tests/luarocks_installation.rs
+++ b/lux-lib/tests/luarocks_installation.rs
@@ -4,7 +4,6 @@ use assert_fs::assert::PathAssert;
 use assert_fs::prelude::{PathChild, PathCopy};
 use assert_fs::TempDir;
 use lux_lib::lua_installation::detect_installed_lua_version;
-use lux_lib::operations::LuaBinary;
 use lux_lib::progress::{MultiProgress, Progress, ProgressBar};
 use lux_lib::{
     config::{ConfigBuilder, LuaVersion},
@@ -17,11 +16,7 @@ use predicates::prelude::predicate;
 async fn luarocks_make() {
     let dir = TempDir::new().unwrap();
 
-    let lua_version = detect_installed_lua_version(LuaBinary::default())
-        .await
-        .ok()
-        .and_then(|version| LuaVersion::from_version(version).ok())
-        .or(Some(LuaVersion::Lua51));
+    let lua_version = detect_installed_lua_version().or(Some(LuaVersion::Lua51));
 
     let config = ConfigBuilder::new()
         .unwrap()

--- a/lux-lib/tests/test.rs
+++ b/lux-lib/tests/test.rs
@@ -4,7 +4,7 @@ use assert_fs::prelude::PathCopy;
 use lux_lib::{
     config::{ConfigBuilder, LuaVersion},
     lua_installation::detect_installed_lua_version,
-    operations::{LuaBinary, Test},
+    operations::Test,
     project::Project,
 };
 
@@ -19,11 +19,7 @@ async fn run_busted_test() {
     let tree_root = project.root().to_path_buf().join(".lux");
     let _ = std::fs::remove_dir_all(&tree_root);
 
-    let lua_version = detect_installed_lua_version(LuaBinary::default())
-        .await
-        .ok()
-        .and_then(|version| LuaVersion::from_version(version).ok())
-        .or(Some(LuaVersion::Lua51));
+    let lua_version = detect_installed_lua_version().or(Some(LuaVersion::Lua51));
 
     let config = ConfigBuilder::new()
         .unwrap()
@@ -46,11 +42,7 @@ async fn run_busted_test_no_lock() {
     let tree_root = project.root().to_path_buf().join(".lux");
     let _ = std::fs::remove_dir_all(&tree_root);
 
-    let lua_version = detect_installed_lua_version(LuaBinary::default())
-        .await
-        .ok()
-        .and_then(|version| LuaVersion::from_version(version).ok())
-        .or(Some(LuaVersion::Lua51));
+    let lua_version = detect_installed_lua_version().or(Some(LuaVersion::Lua51));
 
     let config = ConfigBuilder::new()
         .unwrap()

--- a/lux-lib/tests/tree.rs
+++ b/lux-lib/tests/tree.rs
@@ -2,7 +2,6 @@ use assert_fs::TempDir;
 use lux_lib::{
     config::{ConfigBuilder, LuaVersion},
     lua_installation::detect_installed_lua_version,
-    operations::LuaBinary,
 };
 use mlua::{IntoLua, Lua};
 
@@ -12,11 +11,7 @@ async fn tree_userdata() {
 
     let lua = Lua::new();
 
-    let lua_version = detect_installed_lua_version(LuaBinary::default())
-        .await
-        .ok()
-        .and_then(|version| LuaVersion::from_version(version).ok())
-        .or(Some(LuaVersion::Lua51));
+    let lua_version = detect_installed_lua_version().or(Some(LuaVersion::Lua51));
 
     let config = ConfigBuilder::new()
         .unwrap()


### PR DESCRIPTION
Fixes #745.

Our `lua` binary detection currently doesn't take the specified Lua version into account.