### PR TITLE
feat: busted-nlua test backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,7 @@
 /.lux/*
 /lux.lock
 /lux.toml
+spec/
+.busted
 
 .pre-commit-config.yaml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2280,6 +2280,7 @@ dependencies = [
  "insta",
  "is_executable",
  "itertools 0.14.0",
+ "lazy_static",
  "lets_find_up",
  "lua-src",
  "luajit-src",

--- a/lux-cli/src/install_lua.rs
+++ b/lux-cli/src/install_lua.rs
@@ -16,7 +16,7 @@ pub async fn install_lua(config: Config) -> Result<()> {
 
     // TODO: Detect when path already exists by checking `Lua::path()` and prompt the user
     // whether they'd like to forcefully reinstall.
-    let lua = LuaInstallation::install(version_stringified, &config);
+    let lua = LuaInstallation::install(version_stringified, &config).await;
     let lua_root = lua
         .includes()
         .first()

--- a/lux-cli/src/lib.rs
+++ b/lux-cli/src/lib.rs
@@ -211,9 +211,27 @@ pub enum Commands {
     ///     flags = [ ] # Optional CLI flags to pass to busted{n}
     ///     ```{n}
     ///     {n}
-    ///     `lx test` will default to using `busted`{n}
-    ///     if there is a `.busted` file in the project root{n}
-    ///     and no test backend is specified.{n}
+    ///     `lx test` will default to using `busted` if no test backend is specified and:{n}
+    ///         * there is a `.busted` file in the project root{n}
+    ///         * or `busted` is one of the `test_dependencies`).{n}
+    /// {n}
+    ///   - busted-nlua:{n}:
+    ///     {n}
+    ///     [currently broken on macOS and Windows]
+    ///     A build backend for running busted tests with Neovim as the Lua interpreter.
+    ///     Used for testing Neovim plugins.
+    ///     {n}
+    ///     Example:{n}
+    ///     {n}
+    ///     ```toml{n}
+    ///     [test]{n}
+    ///     type = "busted-nlua"{n}
+    ///     flags = [ ] # Optional CLI flags to pass to busted{n}
+    ///     ```{n}
+    ///     {n}
+    ///     `lx test` will default to using `busted-nlua` if no test backend is specified and:{n}
+    ///         * there is a `.busted` file in the project root{n}
+    ///         * or `busted` and `nlua` are `test_dependencies`.{n}
     /// {n}
     ///   - command:{n}
     ///     {n}

--- a/lux-cli/src/pack.rs
+++ b/lux-cli/src/pack.rs
@@ -83,23 +83,26 @@ pub async fn pack(args: Pack, config: Config) -> Result<()> {
                         .install()
                         .await?;
                     let package = packages.first().unwrap();
-                    let rock_path =
-                        operations::Pack::new(dest_dir, tree, package.clone()).pack()?;
+                    let rock_path = operations::Pack::new(dest_dir, tree, package.clone())
+                        .pack()
+                        .await?;
                     Ok(rock_path)
                 }
                 lux_lib::tree::RockMatches::Single(local_package_id) => {
                     let lockfile = user_tree.lockfile()?;
                     let package = lockfile.get(&local_package_id).unwrap();
-                    let rock_path =
-                        operations::Pack::new(dest_dir, user_tree, package.clone()).pack()?;
+                    let rock_path = operations::Pack::new(dest_dir, user_tree, package.clone())
+                        .pack()
+                        .await?;
                     Ok(rock_path)
                 }
                 lux_lib::tree::RockMatches::Many(vec) => {
                     let local_package_id = vec.first().unwrap();
                     let lockfile = user_tree.lockfile()?;
                     let package = lockfile.get(local_package_id).unwrap();
-                    let rock_path =
-                        operations::Pack::new(dest_dir, user_tree, package.clone()).pack()?;
+                    let rock_path = operations::Pack::new(dest_dir, user_tree, package.clone())
+                        .pack()
+                        .await?;
                     Ok(rock_path)
                 }
             }
@@ -124,7 +127,9 @@ pub async fn pack(args: Pack, config: Config) -> Result<()> {
             let package = Build::new(&rockspec, &tree, tree::EntryType::Entrypoint, &config, &bar)
                 .build()
                 .await?;
-            let rock_path = operations::Pack::new(dest_dir, tree, package).pack()?;
+            let rock_path = operations::Pack::new(dest_dir, tree, package)
+                .pack()
+                .await?;
             Ok(rock_path)
         }
     };

--- a/lux-lib/Cargo.toml
+++ b/lux-lib/Cargo.toml
@@ -83,6 +83,7 @@ nonempty = { version = "0.11.0", features = ["serialize"] }
 is_executable = "1.0.4"
 path-slash = "0.2.1"
 chumsky = "0.10.1"
+lazy_static = "1.5.0"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 gpgme = "0.11.0"

--- a/lux-lib/resources/test/sample-project-busted-nlua/.busted
+++ b/lux-lib/resources/test/sample-project-busted-nlua/.busted
@@ -1,0 +1,12 @@
+return {
+  _all = {
+    coverage = false,
+    lpath = "lua/?.lua;lua/?/init.lua",
+  },
+  default = {
+    verbose = true
+  },
+  tests = {
+    verbose = true
+  },
+}

--- a/lux-lib/resources/test/sample-project-busted-nlua/.gitignore
+++ b/lux-lib/resources/test/sample-project-busted-nlua/.gitignore
@@ -1,0 +1,2 @@
+.lux/*
+lux.lock

--- a/lux-lib/resources/test/sample-project-busted-nlua/lua/foo.lua
+++ b/lux-lib/resources/test/sample-project-busted-nlua/lua/foo.lua
@@ -1,0 +1,1 @@
+return true

--- a/lux-lib/resources/test/sample-project-busted-nlua/lux.toml
+++ b/lux-lib/resources/test/sample-project-busted-nlua/lux.toml
@@ -1,0 +1,12 @@
+package = "sample-project"
+version = "0.1.0"
+lua = ">=5.1"
+
+[source]
+url = "https://github.com/nvim-neorocks/luarocks-stub"
+
+[build]
+type = "builtin"
+
+[test_dependencies]
+nlua = "0.3.2"

--- a/lux-lib/resources/test/sample-project-busted-nlua/spec/example_spec.lua
+++ b/lux-lib/resources/test/sample-project-busted-nlua/spec/example_spec.lua
@@ -1,0 +1,6 @@
+describe('Test example', function()
+  it('Test can access vim namespace', function()
+    assert(vim, 'Cannot access vim namespace')
+    assert.are.same(vim.trim('  a '), 'a')
+  end)
+end)

--- a/lux-lib/src/build/mod.rs
+++ b/lux-lib/src/build/mod.rs
@@ -422,7 +422,7 @@ where
                 tree::EntryType::DependencyOnly => tree.dependency(&package)?,
             };
 
-            let lua = LuaInstallation::new(&lua_version, build.config);
+            let lua = LuaInstallation::new(&lua_version, build.config).await;
 
             let rock_source = rockspec.source().current_platform();
             let build_dir = match &rock_source.unpack_dir {
@@ -504,10 +504,10 @@ where
                         .is_some_and(|name| name != "doc" && name != "docs")
                 })
             {
-                recursive_copy_dir(&build_dir.join(directory), &output_paths.etc)?;
+                recursive_copy_dir(&build_dir.join(directory), &output_paths.etc).await?;
             }
 
-            recursive_copy_doc_dir(&output_paths, &build_dir)?;
+            recursive_copy_doc_dir(&output_paths, &build_dir).await?;
 
             if let Ok(rockspec_str) = rockspec.to_lua_remote_rockspec_string() {
                 std::fs::write(output_paths.rockspec_path(), rockspec_str)?;
@@ -518,12 +518,15 @@ where
     }
 }
 
-fn recursive_copy_doc_dir(output_paths: &RockLayout, build_dir: &Path) -> Result<(), BuildError> {
+async fn recursive_copy_doc_dir(
+    output_paths: &RockLayout,
+    build_dir: &Path,
+) -> Result<(), BuildError> {
     let mut doc_dir = build_dir.join("doc");
     if !doc_dir.exists() {
         doc_dir = build_dir.join("docs");
     }
-    recursive_copy_dir(&doc_dir, &output_paths.doc)?;
+    recursive_copy_dir(&doc_dir, &output_paths.doc).await?;
     Ok(())
 }
 
@@ -572,7 +575,7 @@ mod tests {
             doc: dest_dir.join("doc"),
         };
         let lua_version = config.lua_version().unwrap_or(&LuaVersion::Lua51);
-        let lua = LuaInstallation::new(lua_version, &config);
+        let lua = LuaInstallation::new(lua_version, &config).await;
         let project = Project::from(&project_root).unwrap().unwrap();
         let rockspec = project.toml().into_remote().unwrap();
         let progress = Progress::Progress(MultiProgress::new());

--- a/lux-lib/src/build/source.rs
+++ b/lux-lib/src/build/source.rs
@@ -122,7 +122,7 @@ pub(crate) async fn build(
                 dir.file_name()
                     .is_some_and(|name| name != "doc" && name != "docs")
             }) {
-                recursive_copy_dir(&build_dir.join(directory), &output_paths.etc)?;
+                recursive_copy_dir(&build_dir.join(directory), &output_paths.etc).await?;
             }
         }
         None => {
@@ -149,7 +149,8 @@ pub(crate) async fn build(
                 recursive_copy_dir(
                     &build_dir.join(&subdirectory),
                     &output_paths.etc.join(&subdirectory),
-                )?;
+                )
+                .await?;
             }
         }
     }

--- a/lux-lib/src/lua_installation/mod.rs
+++ b/lux-lib/src/lua_installation/mod.rs
@@ -22,6 +22,7 @@ use crate::{
     variables::HasVariables,
 };
 
+#[derive(Debug)]
 pub struct LuaInstallation {
     pub version: LuaVersion,
     dependency_info: ExternalDependencyInfo,

--- a/lux-lib/src/lua_installation/mod.rs
+++ b/lux-lib/src/lua_installation/mod.rs
@@ -7,20 +7,29 @@ use std::io;
 use std::path::Path;
 use std::path::PathBuf;
 use target_lexicon::Triple;
+use tempdir::TempDir;
 use thiserror::Error;
 use which::which;
 
 use crate::build::external_dependency::to_lib_name;
 use crate::build::external_dependency::ExternalDependencyInfo;
+use crate::build::utils::recursive_copy_dir;
 use crate::build::utils::{c_lib_extension, format_path};
 use crate::config::external_deps::ExternalDependencySearchConfig;
 use crate::lua_rockspec::ExternalDependencySpec;
-use crate::project::Project;
 use crate::{
     config::{Config, LuaVersion},
     package::PackageVersion,
     variables::HasVariables,
 };
+use lazy_static::lazy_static;
+use tokio::sync::Mutex;
+
+// Because installing lua is not thread-safe, we have to synchronize with a global Mutex
+lazy_static! {
+    static ref NEW_MUTEX: Mutex<i32> = Mutex::new(0i32);
+    static ref INSTALL_MUTEX: Mutex<i32> = Mutex::new(0i32);
+}
 
 #[derive(Debug)]
 pub struct LuaInstallation {
@@ -64,23 +73,24 @@ pub enum DetectLuaVersionError {
 }
 
 impl LuaInstallation {
-    pub fn new(version: &LuaVersion, config: &Config) -> Self {
+    pub async fn new(version: &LuaVersion, config: &Config) -> Self {
+        let _lock = NEW_MUTEX.lock().await;
         if let Some(lua_intallation) = Self::probe(version, config.external_deps()) {
             return lua_intallation;
         }
         let output = Self::root_dir(version, config);
-        if output.join("include").is_dir() {
+        let include_dir = output.join("include");
+        let lib_dir = output.join("lib");
+        let lua_lib_name = get_lua_lib_name(&lib_dir, version);
+        if include_dir.is_dir() && lua_lib_name.is_some() {
             let bin_dir = Some(output.join("bin")).filter(|bin_path| bin_path.is_dir());
             let bin = bin_dir
                 .as_ref()
                 .and_then(|bin_path| find_lua_executable(bin_path));
-            let lib_dir = output.join("lib");
-            let lua_lib_name = get_lua_lib_name(&lib_dir, version);
-            let include_dir = Some(output.join("include"));
             LuaInstallation {
                 version: version.clone(),
                 dependency_info: ExternalDependencyInfo {
-                    include_dir,
+                    include_dir: Some(include_dir),
                     lib_dir: Some(lib_dir),
                     bin_dir,
                     lib_info: None,
@@ -89,7 +99,7 @@ impl LuaInstallation {
                 bin,
             }
         } else {
-            Self::install(version, config)
+            Self::install(version, config).await
         }
     }
 
@@ -134,12 +144,16 @@ impl LuaInstallation {
         }
     }
 
-    pub fn install(version: &LuaVersion, config: &Config) -> Self {
+    // XXX: lua_src and luajit_src panic on failure, so we just unwrap errors here.
+    pub async fn install(version: &LuaVersion, config: &Config) -> Self {
+        let _lock = INSTALL_MUTEX.lock().await;
         let host = Triple::host();
         let target = &host.to_string();
         let host_operating_system = &host.operating_system.to_string();
 
-        let output = Self::root_dir(version, config);
+        let output = TempDir::new("lux_lua_installation")
+            .expect("failed to create lua_installation temp directory");
+
         let (include_dir, lib_dir) = match version {
             LuaVersion::LuaJIT | LuaVersion::LuaJIT52 => {
                 // XXX: luajit_src panics if this is not set.
@@ -178,11 +192,17 @@ impl LuaInstallation {
             }
         };
 
-        let bin_dir = Some(output.join("bin")).filter(|bin_path| bin_path.is_dir());
+        let target = Self::root_dir(version, config);
+        recursive_copy_dir(&output.into_path(), &target)
+            .await
+            .expect("error copying lua installation");
+
+        let bin_dir = Some(target.join("bin")).filter(|bin_path| bin_path.is_dir());
         let bin = bin_dir
             .as_ref()
             .and_then(|bin_path| find_lua_executable(bin_path));
         let lua_lib_name = get_lua_lib_name(&lib_dir, version);
+
         LuaInstallation {
             version: version.clone(),
             dependency_info: ExternalDependencyInfo {
@@ -203,10 +223,6 @@ impl LuaInstallation {
     fn root_dir(version: &LuaVersion, config: &Config) -> PathBuf {
         if let Some(lua_dir) = config.lua_dir() {
             return lua_dir.clone();
-        } else if let Ok(Some(project)) = Project::current() {
-            if let Ok(tree) = project.tree(config) {
-                return tree.root().join(".lua");
-            }
         } else if let Ok(tree) = config.user_tree(version.clone()) {
             return tree.root().join(".lua");
         }
@@ -486,7 +502,7 @@ mod test {
         }
         let config = ConfigBuilder::new().unwrap().build().unwrap();
         let lua_version = config.lua_version().unwrap();
-        let lua_installation = LuaInstallation::new(lua_version, &config);
+        let lua_installation = LuaInstallation::new(lua_version, &config).await;
         // FIXME: This fails when run in the nix checkPhase
         assert!(lua_installation.bin.is_some());
         let lua_binary: LuaBinary = lua_installation.bin.unwrap().into();

--- a/lux-lib/src/luarocks/install_binary_rock.rs
+++ b/lux-lib/src/luarocks/install_binary_rock.rs
@@ -217,7 +217,7 @@ async fn install_manifest_entries<T>(
         let target = dest.join(relative_src_path);
         let src_path = src.join(relative_src_path);
         if src_path.is_dir() {
-            recursive_copy_dir(&src.to_path_buf(), &target)?;
+            recursive_copy_dir(&src.to_path_buf(), &target).await?;
         } else if src_path.is_file() {
             tokio::fs::create_dir_all(target.parent().unwrap()).await?;
             tokio::fs::copy(src.join(relative_src_path), target).await?;
@@ -312,6 +312,7 @@ mod test {
             local_package.clone(),
         )
         .pack()
+        .await
         .unwrap();
         assert_eq!(
             packed_rock

--- a/lux-lib/src/operations/fetch.rs
+++ b/lux-lib/src/operations/fetch.rs
@@ -241,7 +241,7 @@ async fn do_fetch_src<R: Rockspec>(
         RockSourceSpec::File(path) => {
             let hash = if path.is_dir() {
                 progress.map(|p| p.set_message(format!("📋 Copying {}", path.display())));
-                recursive_copy_dir(&path.to_path_buf(), dest_dir)?;
+                recursive_copy_dir(&path.to_path_buf(), dest_dir).await?;
                 progress.map(|p| p.finish_and_clear());
                 dest_dir.hash()?
             } else {

--- a/lux-lib/src/operations/pack.rs
+++ b/lux-lib/src/operations/pack.rs
@@ -47,8 +47,8 @@ impl<State> PackBuilder<State>
 where
     State: pack_builder::State + pack_builder::IsComplete,
 {
-    pub fn pack(self) -> Result<PathBuf, PackError> {
-        do_pack(self._build())
+    pub async fn pack(self) -> Result<PathBuf, PackError> {
+        do_pack(self._build()).await
     }
 }
 
@@ -60,7 +60,7 @@ pub enum PackError {
     Walkdir(#[from] walkdir::Error),
 }
 
-fn do_pack(args: Pack) -> Result<PathBuf, PackError> {
+async fn do_pack(args: Pack) -> Result<PathBuf, PackError> {
     let package = args.package;
     let tree = args.tree;
     let layout = tree.entrypoint_layout(&package);
@@ -79,7 +79,7 @@ fn do_pack(args: Pack) -> Result<PathBuf, PackError> {
     let doc_entries = add_rock_entries(&mut zip, &layout.doc, "doc".into())?;
     // We copy entries from `etc` to the root directory, as luarocks doesn't have an etc directory.
     let temp_dir = TempDir::new("lux-pack-temp-root").unwrap().into_path();
-    utils::recursive_copy_dir(&layout.etc, &temp_dir)?;
+    utils::recursive_copy_dir(&layout.etc, &temp_dir).await?;
     // prevent duplicate doc entries
     let doc = temp_dir.join("doc");
     if doc.is_dir() {

--- a/lux-lib/src/operations/sync.rs
+++ b/lux-lib/src/operations/sync.rs
@@ -56,15 +56,21 @@ where
 
     pub async fn sync_test_dependencies(mut self) -> Result<SyncReport, SyncError> {
         let toml = self.project.toml().into_local()?;
-        if let Some(test_runner) = toml.test().current_platform().runner(self.project.root()) {
-            if !toml
-                .test_dependencies()
-                .current_platform()
-                .iter()
-                .any(|dep| dep.name() == test_runner.name())
-            {
-                self.extra_packages.push(test_runner);
-            }
+        for test_dep in toml
+            .test()
+            .current_platform()
+            .test_dependencies(self.project)
+            .iter()
+            .filter(|test_dep| {
+                !toml
+                    .test_dependencies()
+                    .current_platform()
+                    .iter()
+                    .any(|dep| dep.name() == test_dep.name())
+            })
+            .cloned()
+        {
+            self.extra_packages.push(test_dep);
         }
         do_sync(self._build(), &LocalPackageLockType::Test).await
     }

--- a/lux-lib/tests/exec.rs
+++ b/lux-lib/tests/exec.rs
@@ -3,21 +3,19 @@ use lux_lib::{
     config::ConfigBuilder,
     operations::{install_command, Exec},
 };
-#[cfg(not(target_env = "msvc"))]
-use tempdir::TempDir;
 
 #[cfg(not(target_env = "msvc"))]
 #[tokio::test]
 async fn run_nlua() {
     use lux_lib::{config::LuaVersion, lua_installation::detect_installed_lua_version};
 
-    let dir = TempDir::new("lux-test").unwrap();
+    let dir = assert_fs::TempDir::new().unwrap();
 
     let lua_version = detect_installed_lua_version().or(Some(LuaVersion::Lua51));
 
     let config = ConfigBuilder::new()
         .unwrap()
-        .user_tree(Some(dir.into_path()))
+        .user_tree(Some(dir.to_path_buf()))
         .lua_version(lua_version)
         .build()
         .unwrap();

--- a/lux-lib/tests/luarocks_installation.rs
+++ b/lux-lib/tests/luarocks_installation.rs
@@ -36,7 +36,7 @@ async fn luarocks_make() {
     build_dir.copy_from(&project_root, &["**"]).unwrap();
     let dest_dir = TempDir::new().unwrap();
     let lua_version = LuaVersion::from(&config).unwrap_or(&LuaVersion::Lua51);
-    let lua = LuaInstallation::new(lua_version, &config);
+    let lua = LuaInstallation::new(lua_version, &config).await;
     luarocks
         .make(&rockspec_path, build_dir.path(), dest_dir.path(), &lua)
         .await

--- a/lux-lib/tests/test.rs
+++ b/lux-lib/tests/test.rs
@@ -84,16 +84,22 @@ async fn non_regression_lockfile_corruption() {
     assert_eq!(lockfile_before_test, lockfile_after_test);
 }
 
+#[cfg(target_os = "linux")]
 #[tokio::test]
 async fn run_busted_nlua_test() {
     run_busted_nlua_test_impl(false).await
 }
 
+#[cfg(target_os = "linux")]
 #[tokio::test]
 async fn run_busted_nlua_test_no_lock() {
     run_busted_nlua_test_impl(true).await
 }
 
+// NOTE: The busted-nlua test backend is currently broken on macOS and Windows.
+// On macOS, it appears that Neovim segfaults when `require`ing `lfs` (luafilesystem).
+// Investigation is needed on Windows.
+#[cfg(target_os = "linux")]
 async fn run_busted_nlua_test_impl(no_lock: bool) {
     let project_root =
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("resources/test/sample-project-busted-nlua");


### PR DESCRIPTION
Closes #715.
Supersedes #716.

This implements a `busted-nlua` test backend.
It also adds a fix to prevent race conditions when installing lua sources.