### PR TITLE
refactor(lux-lua): make `new` match exact project path and add `new_fuzzy`

### DIFF
--- a/lux-lua/src/project.rs
+++ b/lux-lua/src/project.rs
@@ -13,6 +13,11 @@ pub fn project(lua: &Lua) -> mlua::Result<Table> {
 
     table.set(
         "new",
+        lua.create_function(|_, path: PathBuf| Project::from_exact(path).into_lua_err())?,
+    )?;
+
+    table.set(
+        "new_fuzzy",
         lua.create_function(|_, path: PathBuf| Project::from(path).into_lua_err())?,
     )?;
 


### PR DESCRIPTION
small usability fix that is going to help improve speeds and prevent unnecessary directory traversals