### PR TITLE
feat(repl): alias `exit` to `os.exit()`

### DIFF
--- a/lux-lib/src/path.rs
+++ b/lux-lib/src/path.rs
@@ -94,9 +94,9 @@ impl Paths {
     pub fn init(&self) -> String {
         format!(
             r#"
-        if _VERSION:find('{}') then {LUA_INIT} end
-        exit = os.exit
-        setmetatable(exit, {__tostring = function(...) return os.exit() end})
+            exit = os.exit
+            setmetatable(exit, {__tostring = function(...) return os.exit() end})
+            if _VERSION:find('{}') then {LUA_INIT} end
         "#,
             self.version
         )

--- a/lux-lib/src/path.rs
+++ b/lux-lib/src/path.rs
@@ -95,7 +95,7 @@ impl Paths {
         format!(
             r#"
             exit = os.exit
-            setmetatable(exit, {__tostring = function(...) return os.exit() end})
+            setmetatable(exit, {{__tostring = function(...) return os.exit() end}})
             if _VERSION:find('{}') then {LUA_INIT} end
         "#,
             self.version

--- a/lux-lib/src/path.rs
+++ b/lux-lib/src/path.rs
@@ -92,7 +92,13 @@ impl Paths {
 
     /// Get `$LUA_INIT`
     pub fn init(&self) -> String {
-        format!("if _VERSION:find('{}') then {LUA_INIT} end", self.version)
+        format!(
+            r#"
+        if _VERSION:find('{}') then {LUA_INIT} end
+        exit = os.exit
+        "#,
+            self.version
+        )
     }
 
     /// Get the `$PATH`, prepended to the existing `$PATH` environment.

--- a/lux-lib/src/path.rs
+++ b/lux-lib/src/path.rs
@@ -96,6 +96,7 @@ impl Paths {
             r#"
         if _VERSION:find('{}') then {LUA_INIT} end
         exit = os.exit
+        setmetatable(exit, {__tostring = function(...) return os.exit() end})
         "#,
             self.version
         )


### PR DESCRIPTION
Fixes #526 
Succeeds #790 (I renamed the branch)

You can set `exit` equal to `os.exit` so that you can run `exit()` in a lua repl