### PR TITLE
fix(upload): construction of luarocks server URLs

### DIFF
--- a/lux-lib/src/upload/mod.rs
+++ b/lux-lib/src/upload/mod.rs
@@ -315,9 +315,9 @@ mod helpers {
     ) -> Result<Url, url::ParseError> {
         let api_key = unsafe { api_key.get() };
         server_url
-            .join("api/1")
-            .expect("error constructing 'api/1' path")
-            .join(api_key)?
+            .join("api/1/")
+            .expect("error constructing 'api/1/' path")
+            .join(&format!("{}/", api_key))?
             .join(endpoint)
     }
 


### PR DESCRIPTION
Fixes #794 

Trailing slashes are important when calling `.join` on a URL. Without them, the last component gets replaced.