### PR TITLE
feat: expose shell completions in main binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,9 +493,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.46"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5c5508ea23c5366f77e53f5a0070e5a84e51687ec3ef9e0464c86dc8d13ce98"
+checksum = "aad5b1b4de04fead402672b48897030eec1f3bfe1550776322f59f6d6e6a5677"
 dependencies = [
  "clap 4.5.38",
 ]
@@ -2234,6 +2234,7 @@ version = "0.8.0"
 dependencies = [
  "assert_fs",
  "clap 4.5.38",
+ "clap_complete",
  "edit",
  "eyre",
  "git-url-parse",

--- a/lux-cli/Cargo.toml
+++ b/lux-cli/Cargo.toml
@@ -18,6 +18,7 @@ bench = false
 
 [dependencies]
 clap = { version = "4.5.38", features = ["derive"] }
+clap_complete = "4.5.54"
 eyre = "0.6.12"
 git-url-parse = "0.4.5"
 git2 = "0.20.2"

--- a/lux-cli/src/bin/lx.rs
+++ b/lux-cli/src/bin/lx.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use clap::Parser;
 use eyre::Result;
 use lux_cli::{
-    add, build, check, config,
+    add, build, check, completion, config,
     debug::Debug,
     doc, download, exec, fetch, format, generate_rockspec, info, install, install_lua,
     install_rockspec, list, outdated, pack, path, pin, project, purge, remove, run, run_lua,
@@ -48,6 +48,7 @@ async fn main() -> Result<()> {
     let config = config_builder.build()?;
 
     match cli.command {
+        Commands::Completion { shell } => completion::generate(shell).await?,
         Commands::Search(search_data) => search::search(search_data, config).await?,
         Commands::Download(download_data) => download::download(download_data, config).await?,
         Commands::Debug(debug) => match debug {

--- a/lux-cli/src/completion.rs
+++ b/lux-cli/src/completion.rs
@@ -1,0 +1,11 @@
+use clap::CommandFactory;
+use clap_complete::generate as clap_generate;
+use clap_complete::Shell;
+use eyre::Result;
+
+use crate::Cli;
+
+pub async fn generate(shell: Shell) -> Result<()> {
+    clap_generate(shell, &mut Cli::command(), "lx", &mut std::io::stdout());
+    Ok(())
+}

--- a/lux-cli/src/lib.rs
+++ b/lux-cli/src/lib.rs
@@ -150,7 +150,9 @@ pub enum Commands {
     Config(ConfigCmd),
     /// Generate autocompletion scripts for the shell.
     Completion {
-        /// The shell to generate the completion script for.
+        /// The shell to generate the completion script for.{n}
+        /// If not set, Lux will try to detect the current shell.{n}
+        /// Possible values: "bash", "elvish", "fish", "powershell", "zsh"{n}
         #[arg(value_enum, default_value = "bash")]
         shell: clap_complete::Shell,
     },

--- a/lux-cli/src/lib.rs
+++ b/lux-cli/src/lib.rs
@@ -36,6 +36,7 @@ use which::Which;
 pub mod add;
 pub mod build;
 pub mod check;
+pub mod completion;
 pub mod config;
 pub mod debug;
 pub mod doc;
@@ -147,6 +148,12 @@ pub enum Commands {
     /// Interact with the lux configuration.
     #[command(subcommand, arg_required_else_help = true)]
     Config(ConfigCmd),
+    /// Generate autocompletion scripts for the shell.
+    Completion {
+        /// The shell to generate the completion script for.
+        #[arg(value_enum, default_value = "bash")]
+        shell: clap_complete::Shell,
+    },
     /// Internal commands for debugging Lux itself.
     #[command(subcommand, arg_required_else_help = true)]
     Debug(Debug),

--- a/lux-cli/src/lib.rs
+++ b/lux-cli/src/lib.rs
@@ -148,7 +148,8 @@ pub enum Commands {
     /// Interact with the lux configuration.
     #[command(subcommand, arg_required_else_help = true)]
     Config(ConfigCmd),
-    /// Generate autocompletion scripts for the shell.
+    /// Generate autocompletion scripts for the shell.{n}
+    /// Example: `lx completion zsh > ~/.zsh/completions/_lx`
     Completion {
         /// The shell to generate the completion script for.{n}
         /// If not set, Lux will try to detect the current shell.{n}


### PR DESCRIPTION
Hi! 👋 

As an user that installed lux via cargo install, I wanted to have an option to generate autocompletions right from the CLI. That allows me to easily do:

```bash
lx completion zsh > ~/.zsh/completions/_lx
```

## Result

```
➜  lux git:(feature/add-shell-completions) ./target/debug/lx completion --help
Generate autocompletion scripts for the shell

Usage: lx completion [SHELL]

Arguments:
  [SHELL]  The shell to generate the completion script for [default: bash] [possible values: bash, elvish, fish, powershell, zsh]

Options:
  -h, --help  Print help
```

I later noticed that there’s already some related logic in [xtask/src/main.rs](https://github.com/nvim-neorocks/lux/blob/7ca3daec6c5ea237253846abb1f06bbf85f94ceb/xtask/src/main.rs), though it seems intended for a different use case. I’m not sure if or how these should be unified, so open to feedback on that!