### PR TITLE
fix(build)!: `copy_directorys` drops subdirectories

### DIFF
--- a/lux-lib/resources/test/sample-project-no-source/lux.toml
+++ b/lux-lib/resources/test/sample-project-no-source/lux.toml
@@ -14,9 +14,11 @@ labels = ["luarocks", "package-manager"]
 
 [build]
 type = "builtin"
+copy_directories = [ "plugin" ]
 
 [build.modules]
 "foo.main" = "lua/foo.lua"
 
 [build.install]
 conf = { "foo/bar.toml" = "bar.toml" }
+

--- a/lux-lib/src/build/mod.rs
+++ b/lux-lib/src/build/mod.rs
@@ -457,7 +457,11 @@ where
                         .is_some_and(|name| name != "doc" && name != "docs")
                 })
             {
-                recursive_copy_dir(&build_dir.join(directory), &output_paths.etc).await?;
+                recursive_copy_dir(
+                    &build_dir.join(directory),
+                    &output_paths.etc.join(directory),
+                )
+                .await?;
             }
 
             recursive_copy_doc_dir(&output_paths, &build_dir).await?;

--- a/lux-lib/tests/build.rs
+++ b/lux-lib/tests/build.rs
@@ -223,6 +223,9 @@ async fn test_build_local_project_no_source() {
     let rock_layout = tree.installed_rock_layout(&package).unwrap();
     let conf_file = rock_layout.conf.join("foo").join("bar.toml");
     assert!(conf_file.is_file());
+
+    let plugin_file = rock_layout.etc.join("plugin").join("foo.lua");
+    assert!(plugin_file.is_file());
 }
 
 #[tokio::test]


### PR DESCRIPTION
Stacked on #841. 
Fixes #839.