### PR TITLE
feat: pretty-print generated lua code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2323,6 +2323,7 @@ dependencies = [
  "ssri",
  "strum 0.27.1",
  "strum_macros 0.27.1",
+ "stylua",
  "tar",
  "target-lexicon 0.13.2",
  "tempdir",

--- a/lux-lib/Cargo.toml
+++ b/lux-lib/Cargo.toml
@@ -39,6 +39,7 @@ serde-enum-str = "0.4.0"
 ssri = "9.2.0"
 strum = { version = "0.27" }
 strum_macros = "0.27"
+stylua = { version = "2.1.0", features = ["fromstr", "lua52"] }
 tokio = { version = "1.46.0", features = ["full"] }
 tempdir = "0.3.7"
 vfs = "0.12.1"

--- a/lux-lib/src/lua_rockspec/serde_util.rs
+++ b/lux-lib/src/lua_rockspec/serde_util.rs
@@ -124,34 +124,40 @@ pub(crate) struct DisplayLuaKV {
 
 impl Display for DisplayLuaValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use std::fmt::Write;
+        let mut buf = String::new();
         match self {
             //DisplayLuaValue::Nil => write!(f, "nil"),
             //DisplayLuaValue::Number(n) => write!(f, "{n}"),
-            DisplayLuaValue::Boolean(b) => write!(f, "{b}"),
-            DisplayLuaValue::String(s) => write!(f, "\"{s}\""),
+            DisplayLuaValue::Boolean(b) => write!(buf, "{b}")?,
+            DisplayLuaValue::String(s) => write!(buf, "\"{s}\"")?,
             DisplayLuaValue::List(l) => {
-                writeln!(f, "{{")?;
-
+                writeln!(buf, "{{")?;
                 for item in l {
-                    writeln!(f, "{item},")?;
+                    writeln!(buf, "{item},")?;
                 }
-
-                write!(f, "}}")?;
-
-                Ok(())
+                write!(buf, "}}")?;
             }
             DisplayLuaValue::Table(t) => {
-                writeln!(f, "{{")?;
+                writeln!(buf, "{{")?;
 
                 for item in t {
-                    writeln!(f, "{item},")?;
+                    writeln!(buf, "{item},")?;
                 }
 
-                write!(f, "}}")?;
-
-                Ok(())
+                write!(buf, "}}")?;
             }
-        }
+        };
+        let output = match stylua_lib::format_code(
+            &buf,
+            stylua_lib::Config::default(),
+            None,
+            stylua_lib::OutputVerification::Full,
+        ) {
+            Ok(formatted_code) => formatted_code,
+            Err(_) => buf,
+        };
+        write!(f, "{output}")
     }
 }
 

--- a/lux-lib/src/project/project_toml.rs
+++ b/lux-lib/src/project/project_toml.rs
@@ -911,9 +911,19 @@ version = "{}""#,
 
         template.push(self.local.internal.build.display_lua());
 
-        Ok(std::iter::once(starter)
+        let unformatted_code = std::iter::once(starter)
             .chain(template.into_iter().map(|kv| kv.to_string()))
-            .join("\n\n"))
+            .join("\n\n");
+        let result = match stylua_lib::format_code(
+            &unformatted_code,
+            stylua_lib::Config::default(),
+            None,
+            stylua_lib::OutputVerification::Full,
+        ) {
+            Ok(formatted_code) => formatted_code,
+            Err(_) => unformatted_code,
+        };
+        Ok(result)
     }
 }
 

--- a/lux-lib/src/rockspec/lua_dependency.rs
+++ b/lux-lib/src/rockspec/lua_dependency.rs
@@ -94,7 +94,7 @@ impl Display for LuaDependencySpec {
         if self.version_req().is_any() {
             self.name().fmt(f)
         } else {
-            f.write_str(format!("{} {}", self.name(), self.version_req()).as_str())
+            f.write_str(format!("{}{}", self.name(), self.version_req()).as_str())
         }
     }
 }


### PR DESCRIPTION
Closes #359.

Uses `stylua` (with the default config) instead of `pretty`, as `stylua` is tailored for Lua code.