### PR TITLE
feat!: manage lua installations internally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2365,6 +2365,7 @@ dependencies = [
  "clap 4.5.40",
  "clap_builder",
  "crossbeam-utils",
+ "either",
  "futures-channel",
  "futures-core",
  "futures-sink",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2217,15 +2217,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lua-src"
-version = "548.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00bc4bd1f1d5c65b30717333cbec4fa7aa378978940a1bca62f404498d423233"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "luajit-src"
 version = "210.5.12+a4f56a4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2310,8 +2301,6 @@ dependencies = [
  "itertools 0.14.0",
  "lazy_static",
  "lets_find_up",
- "lua-src 548.1.1",
- "luajit-src",
  "lux-workspace-hack",
  "md5",
  "mlua",
@@ -2533,7 +2522,7 @@ checksum = "380c1f7e2099cafcf40e51d3a9f20a346977587aa4d012eae1f043149a728a93"
 dependencies = [
  "cc",
  "cfg-if",
- "lua-src 547.0.0",
+ "lua-src",
  "luajit-src",
  "pkg-config",
 ]

--- a/lux-cli/src/install_lua.rs
+++ b/lux-cli/src/install_lua.rs
@@ -2,31 +2,33 @@ use eyre::Result;
 use lux_lib::{
     config::{Config, LuaVersion},
     lua_installation::LuaInstallation,
-    progress::{MultiProgress, ProgressBar},
+    progress::{MultiProgress, Progress, ProgressBar},
 };
 
 pub async fn install_lua(config: Config) -> Result<()> {
     let version_stringified = &LuaVersion::from(&config)?;
 
     let progress = MultiProgress::new();
-    let bar = progress.add(ProgressBar::from(format!(
+    let bar = Progress::Progress(progress.add(ProgressBar::from(format!(
         "🌔 Installing Lua ({version_stringified})",
-    )));
+    ))));
 
     // TODO: Detect when path already exists by checking `Lua::path()` and prompt the user
     // whether they'd like to forcefully reinstall.
-    let lua = LuaInstallation::install(version_stringified, &config).await?;
+    let lua = LuaInstallation::install(version_stringified, &config, &bar).await?;
     let lua_root = lua
         .includes()
         .first()
         .and_then(|dir| dir.parent())
         .expect("error getting parent directory");
 
-    bar.finish_with_message(format!(
-        "🌔 Installed Lua ({}) to {}",
-        version_stringified,
-        lua_root.display()
-    ));
+    bar.map(|bar| {
+        bar.finish_with_message(format!(
+            "🌔 Installed Lua ({}) to {}",
+            version_stringified,
+            lua_root.display()
+        ))
+    });
 
     Ok(())
 }

--- a/lux-cli/src/install_rockspec.rs
+++ b/lux-cli/src/install_rockspec.rs
@@ -104,17 +104,16 @@ pub async fn install_rockspec(data: InstallRockspec, config: Config) -> Result<(
         luarocks.ensure_installed(&bar).await?;
     }
 
-    build::Build::new(
-        &rockspec,
-        &tree,
-        tree::EntryType::Entrypoint,
-        &config,
-        &progress.map(|p| p.new_bar()),
-    )
-    .pin(pin)
-    .behaviour(BuildBehaviour::Force)
-    .build()
-    .await?;
+    build::Build::new()
+        .rockspec(&rockspec)
+        .tree(&tree)
+        .entry_type(tree::EntryType::Entrypoint)
+        .config(&config)
+        .progress(&progress.map(|p| p.new_bar()))
+        .pin(pin)
+        .behaviour(BuildBehaviour::Force)
+        .build()
+        .await?;
 
     Ok(())
 }

--- a/lux-cli/src/pack.rs
+++ b/lux-cli/src/pack.rs
@@ -6,6 +6,7 @@ use eyre::{eyre, Result};
 use lux_lib::{
     build::{Build, BuildBehaviour},
     config::{Config, LuaVersion},
+    lua_installation::LuaInstallation,
     lua_rockspec::RemoteLuaRockspec,
     operations::{self, Install, PackageInstallSpec},
     package::PackageReq,
@@ -125,9 +126,16 @@ pub async fn pack(args: Pack, config: Config) -> Result<()> {
             let temp_dir = TempDir::new("lux-pack")?.into_path();
             let bar = progress.map(|p| p.new_bar());
             let config = config.with_tree(temp_dir);
+            let lua = LuaInstallation::new(
+                &lua_version,
+                &config,
+                &progress.map(|progress| progress.new_bar()),
+            )
+            .await?;
             let tree = config.user_tree(lua_version)?;
             let package = Build::new()
                 .rockspec(&rockspec)
+                .lua(&lua)
                 .tree(&tree)
                 .entry_type(tree::EntryType::Entrypoint)
                 .config(&config)

--- a/lux-cli/src/pack.rs
+++ b/lux-cli/src/pack.rs
@@ -126,7 +126,12 @@ pub async fn pack(args: Pack, config: Config) -> Result<()> {
             let bar = progress.map(|p| p.new_bar());
             let config = config.with_tree(temp_dir);
             let tree = config.user_tree(lua_version)?;
-            let package = Build::new(&rockspec, &tree, tree::EntryType::Entrypoint, &config, &bar)
+            let package = Build::new()
+                .rockspec(&rockspec)
+                .tree(&tree)
+                .entry_type(tree::EntryType::Entrypoint)
+                .config(&config)
+                .progress(&bar)
                 .build()
                 .await?;
             let rock_path = operations::Pack::new(dest_dir, tree, package)

--- a/lux-lib/Cargo.toml
+++ b/lux-lib/Cargo.toml
@@ -35,8 +35,6 @@ infer = "0.19.0"
 is_executable = "1.0.4"
 lazy_static = "1.5.0"
 lets_find_up = "0.0.4"
-lua-src = "548.1.1"
-luajit-src = "210.5.12"
 md5 = "0.8.0"
 nix-nar = "0.3.0"
 nonempty = { version = "0.12.0", features = ["serialize"] }

--- a/lux-lib/src/build/mod.rs
+++ b/lux-lib/src/build/mod.rs
@@ -372,7 +372,7 @@ where
                 tree::EntryType::DependencyOnly => tree.dependency(&package)?,
             };
 
-            let lua = LuaInstallation::new(&lua_version, build.config).await?;
+            let lua = LuaInstallation::new(&lua_version, build.config, build.progress).await?;
 
             let rock_source = rockspec.source().current_platform();
             let build_dir = match &rock_source.unpack_dir {
@@ -541,7 +541,11 @@ mod tests {
             doc: dest_dir.join("doc"),
         };
         let lua_version = config.lua_version().unwrap_or(&LuaVersion::Lua51);
-        let lua = LuaInstallation::new(lua_version, &config).await.unwrap();
+        let progress = MultiProgress::new();
+        let bar = Progress::Progress(progress.new_bar());
+        let lua = LuaInstallation::new(lua_version, &config, &bar)
+            .await
+            .unwrap();
         let project = Project::from(&project_root).unwrap().unwrap();
         let rockspec = project.toml().into_remote().unwrap();
         let progress = Progress::Progress(MultiProgress::new());

--- a/lux-lib/src/build/mod.rs
+++ b/lux-lib/src/build/mod.rs
@@ -61,16 +61,10 @@ pub mod external_dependency;
 #[derive(Builder)]
 #[builder(start_fn = new, finish_fn(name = _build, vis = ""))]
 pub struct Build<'a, R: Rockspec + HasIntegrity> {
-    #[builder(start_fn)]
     rockspec: &'a R,
-    #[builder(start_fn)]
     tree: &'a Tree,
-    #[builder(start_fn)]
     entry_type: tree::EntryType,
-    #[builder(start_fn)]
     config: &'a Config,
-
-    #[builder(start_fn)]
     progress: &'a Progress<ProgressBar>,
 
     #[builder(default)]

--- a/lux-lib/src/build/utils.rs
+++ b/lux-lib/src/build/utils.rs
@@ -687,6 +687,7 @@ mod tests {
     use crate::{
         config::{ConfigBuilder, LuaVersion},
         lua_installation::detect_installed_lua_version,
+        progress::{MultiProgress, Progress},
     };
 
     use super::*;
@@ -700,7 +701,11 @@ mod tests {
             .build()
             .unwrap();
         let lua_version = config.lua_version().unwrap();
-        let lua = LuaInstallation::new(lua_version, &config).await.unwrap();
+        let progress = MultiProgress::new();
+        let bar = Progress::Progress(progress.new_bar());
+        let lua = LuaInstallation::new(lua_version, &config, &bar)
+            .await
+            .unwrap();
         let valid_script = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("resources/test/sample_lua_bin_script_valid");
         let temp_dir = assert_fs::TempDir::new().unwrap().to_path_buf();
@@ -721,7 +726,11 @@ mod tests {
             .build()
             .unwrap();
         let lua_version = config.lua_version().unwrap();
-        let lua = LuaInstallation::new(lua_version, &config).await.unwrap();
+        let progress = MultiProgress::new();
+        let bar = Progress::Progress(progress.new_bar());
+        let lua = LuaInstallation::new(lua_version, &config, &bar)
+            .await
+            .unwrap();
         let tree = config.user_tree(lua_version.clone()).unwrap();
         let valid_script = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("resources/test/sample_lua_bin_script_valid");

--- a/lux-lib/src/build/utils.rs
+++ b/lux-lib/src/build/utils.rs
@@ -719,9 +719,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_install_wrapped_binary() {
+        let lua_version = detect_installed_lua_version().or(Some(LuaVersion::Lua51));
         let temp = assert_fs::TempDir::new().unwrap();
         let config = ConfigBuilder::new()
             .unwrap()
+            .lua_version(lua_version)
             .user_tree(Some(temp.to_path_buf()))
             .build()
             .unwrap();

--- a/lux-lib/src/lua_installation/mod.rs
+++ b/lux-lib/src/lua_installation/mod.rs
@@ -13,6 +13,7 @@ use crate::build::external_dependency::to_lib_name;
 use crate::build::external_dependency::ExternalDependencyInfo;
 use crate::build::utils::{c_lib_extension, format_path};
 use crate::config::external_deps::ExternalDependencySearchConfig;
+use crate::config::LuaVersionUnset;
 use crate::lua_rockspec::ExternalDependencySpec;
 use crate::operations;
 use crate::operations::BuildLuaError;
@@ -78,9 +79,18 @@ pub enum DetectLuaVersionError {
 pub enum LuaInstallationError {
     #[error("could not find a Lua installation and failed to build Lua from source:\n{0}")]
     Build(#[from] BuildLuaError),
+    #[error(transparent)]
+    LuaVersionUnset(#[from] LuaVersionUnset),
 }
 
 impl LuaInstallation {
+    pub async fn new_from_config(
+        config: &Config,
+        progress: &Progress<ProgressBar>,
+    ) -> Result<Self, LuaInstallationError> {
+        Self::new(LuaVersion::from(config)?, config, progress).await
+    }
+
     pub async fn new(
         version: &LuaVersion,
         config: &Config,

--- a/lux-lib/src/luarocks/install_binary_rock.rs
+++ b/lux-lib/src/luarocks/install_binary_rock.rs
@@ -123,7 +123,7 @@ impl<'a> BinaryRockInstall<'a> {
             let _ = ExternalDependencyInfo::probe(name, dep, self.config.external_deps())?;
         }
 
-        rockspec.validate_lua_version(self.config)?;
+        rockspec.validate_lua_version_from_config(self.config)?;
 
         let hashes = LocalPackageHashes {
             rockspec: rockspec.hash()?,

--- a/lux-lib/src/luarocks/install_binary_rock.rs
+++ b/lux-lib/src/luarocks/install_binary_rock.rs
@@ -123,7 +123,7 @@ impl<'a> BinaryRockInstall<'a> {
             let _ = ExternalDependencyInfo::probe(name, dep, self.config.external_deps())?;
         }
 
-        rockspec.lua_version_matches(self.config)?;
+        rockspec.validate_lua_version(self.config)?;
 
         let hashes = LocalPackageHashes {
             rockspec: rockspec.hash()?,

--- a/lux-lib/src/luarocks/luarocks_installation.rs
+++ b/lux-lib/src/luarocks/luarocks_installation.rs
@@ -124,16 +124,15 @@ impl LuaRocksInstallation {
 
         if !self.tree.match_rocks(&luarocks_req)?.is_found() {
             let rockspec = RemoteLuaRockspec::new(LUAROCKS_ROCKSPEC).unwrap();
-            let pkg = Build::new(
-                &rockspec,
-                &self.tree,
-                tree::EntryType::Entrypoint,
-                &self.config,
-                progress,
-            )
-            .constraint(luarocks_req.version_req().clone().into())
-            .build()
-            .await?;
+            let pkg = Build::new()
+                .rockspec(&rockspec)
+                .tree(&self.tree)
+                .entry_type(tree::EntryType::Entrypoint)
+                .config(&self.config)
+                .progress(progress)
+                .constraint(luarocks_req.version_req().clone().into())
+                .build()
+                .await?;
             lockfile.add_entrypoint(&pkg);
         }
         Ok(())

--- a/lux-lib/src/luarocks/luarocks_installation.rs
+++ b/lux-lib/src/luarocks/luarocks_installation.rs
@@ -113,6 +113,7 @@ impl LuaRocksInstallation {
     #[cfg(target_family = "unix")]
     pub async fn ensure_installed(
         &self,
+        lua: &LuaInstallation,
         progress: &Progress<ProgressBar>,
     ) -> Result<(), LuaRocksInstallError> {
         use crate::{lua_rockspec::RemoteLuaRockspec, package::PackageReq};
@@ -126,6 +127,7 @@ impl LuaRocksInstallation {
             let rockspec = RemoteLuaRockspec::new(LUAROCKS_ROCKSPEC).unwrap();
             let pkg = Build::new()
                 .rockspec(&rockspec)
+                .lua(lua)
                 .tree(&self.tree)
                 .entry_type(tree::EntryType::Entrypoint)
                 .config(&self.config)
@@ -141,6 +143,7 @@ impl LuaRocksInstallation {
     #[cfg(target_family = "windows")]
     pub async fn ensure_installed(
         &self,
+        _lua: &LuaInstallation,
         progress: &Progress<ProgressBar>,
     ) -> Result<(), LuaRocksInstallError> {
         use crate::{hash::HasIntegrity, operations};

--- a/lux-lib/src/operations/build_lua.rs
+++ b/lux-lib/src/operations/build_lua.rs
@@ -1,0 +1,539 @@
+use std::{
+    env,
+    io::{self, Cursor},
+    path::Path,
+    process::{ExitStatus, Stdio},
+};
+
+use crate::{
+    build::{external_dependency::ExternalDependencyInfo, utils},
+    config::{external_deps::ExternalDependencySearchConfig, Config, LuaVersion},
+    hash::HasIntegrity,
+    lua_rockspec::ExternalDependencySpec,
+    operations::{self, UnpackError},
+    progress::{Progress, ProgressBar},
+};
+use bon::Builder;
+use git2::{build::RepoBuilder, FetchOptions};
+use ssri::Integrity;
+use target_lexicon::Triple;
+use tempdir::TempDir;
+use thiserror::Error;
+use tokio::{fs, process::Command};
+use url::Url;
+
+const LUA51_VERSION: &str = "5.1.5";
+const LUA51_HASH: &str = "sha256-JkD8VqeV8p0o7xXhPDSkfiI5YLAkDoywqC2bBzhpUzM=";
+const LUA52_VERSION: &str = "5.2.4";
+const LUA52_HASH: &str = "sha256-ueLkqtZ4mztjoFbUQveznw7Pyjrg8fwK5OlhRAG2n0s=";
+const LUA53_VERSION: &str = "5.3.6";
+const LUA53_HASH: &str = "sha256-/F/Wm7hzYyPwJmcrG3I12mE9cXfnJViJOgvc0yBGbWA=";
+const LUA54_VERSION: &str = "5.4.8";
+const LUA54_HASH: &str = "sha256-TxjdrhVOeT5G7qtyfFnvHAwMK3ROe5QhlxDXb1MGKa4=";
+// XXX: there's no tag with lua 5.2 compatibility, so we have to use the v2.1 branch for now
+// this is unstable and might break the build.
+const LUAJIT_MM_VERSION: &str = "2.1";
+
+#[derive(Builder)]
+#[builder(start_fn = new, finish_fn(name = _build, vis = ""))]
+pub struct BuildLua<'a> {
+    lua_version: &'a LuaVersion,
+    install_dir: &'a Path,
+    config: &'a Config,
+    progress: &'a Progress<ProgressBar>,
+}
+
+#[derive(Debug, Error)]
+pub enum BuildLuaError {
+    #[error(transparent)]
+    Request(#[from] reqwest::Error),
+    #[error(transparent)]
+    Io(#[from] io::Error),
+    #[error(transparent)]
+    Unpack(#[from] UnpackError),
+    #[error(transparent)]
+    Git(#[from] git2::Error),
+    #[error(transparent)]
+    CC(#[from] cc::Error),
+    #[error("failed to find cl.exe")]
+    ClNotFound,
+    #[error("failed to find LINK.exe")]
+    LinkNotFound,
+    #[error("source integrity mismatch.\nExpected: {expected},\nbut got: {actual}")]
+    SourceIntegrityMismatch {
+        expected: Integrity,
+        actual: Integrity,
+    },
+    #[error("{name} failed.\n\n{status}\n\nstdout:\n{stdout}\n\nstderr:\n{stderr}")]
+    CommandFailure {
+        name: String,
+        status: ExitStatus,
+        stdout: String,
+        stderr: String,
+    },
+}
+
+impl<State: build_lua_builder::State + build_lua_builder::IsComplete> BuildLuaBuilder<'_, State> {
+    pub async fn build(self) -> Result<(), BuildLuaError> {
+        let args = self._build();
+        let lua_version = args.lua_version;
+        match lua_version {
+            LuaVersion::Lua51 | LuaVersion::Lua52 | LuaVersion::Lua53 | LuaVersion::Lua54 => {
+                do_build_lua(args).await
+            }
+            LuaVersion::LuaJIT | LuaVersion::LuaJIT52 => do_build_luajit(args).await,
+        }
+    }
+}
+
+async fn do_build_luajit(args: BuildLua<'_>) -> Result<(), BuildLuaError> {
+    let progress = args.progress;
+
+    let build_dir = TempDir::new("lux_luajit_build_dir")
+        .expect("failed to create lua_installation temp directory")
+        .into_path();
+    // XXX luajit.org responds with an invalid content-type, so we'll use the github mirror for now.
+    // let luajit_url = "https://luajit.org/git/luajit.git";
+    let luajit_url = "https://github.com/LuaJIT/LuaJIT.git";
+    progress.map(|p| p.set_message(format!("🦠 Cloning {luajit_url}")));
+    {
+        // We create a new scope because we have to drop fetch_options before the await
+        let mut fetch_options = FetchOptions::new();
+        fetch_options.update_fetchhead(false);
+        let mut repo_builder = RepoBuilder::new();
+        repo_builder.fetch_options(fetch_options);
+        let repo = repo_builder.clone(luajit_url, &build_dir)?;
+        let (object, _) = repo.revparse_ext(&format!("v{LUAJIT_MM_VERSION}"))?;
+        repo.checkout_tree(&object, None)?;
+    }
+    if cfg!(target_env = "msvc") {
+        do_build_luajit_msvc(args, &build_dir).await
+    } else {
+        do_build_luajit_unix(args, &build_dir).await
+    }
+}
+
+async fn do_build_luajit_unix(args: BuildLua<'_>, build_dir: &Path) -> Result<(), BuildLuaError> {
+    let lua_version = args.lua_version;
+    let config = args.config;
+    let install_dir = args.install_dir;
+    let progress = args.progress;
+    progress.map(|p| p.set_message(format!("🛠️ Building Luajit {LUAJIT_MM_VERSION}")));
+
+    let host = Triple::host();
+
+    let mut cc = cc::Build::new();
+    cc.cargo_output(false)
+        .cargo_metadata(false)
+        .cargo_warnings(false)
+        .warnings(config.verbose())
+        .opt_level(3)
+        .host(std::env::consts::OS)
+        .target(&host.to_string());
+    let compiler = cc.try_get_compiler()?;
+    let compiler_path = compiler.path().to_str().unwrap();
+    let mut make_cmd = Command::new(config.make_cmd());
+    make_cmd.current_dir(build_dir.join("src"));
+    make_cmd.arg("-e");
+    make_cmd.stdout(Stdio::piped());
+    make_cmd.stderr(Stdio::piped());
+    let target = host.to_string();
+    match target.as_str() {
+        "x86_64-apple-darwin" if env::var_os("MACOSX_DEPLOYMENT_TARGET").is_none() => {
+            make_cmd.env("MACOSX_DEPLOYMENT_TARGET", "10.11");
+        }
+        "aarch64-apple-darwin" if env::var_os("MACOSX_DEPLOYMENT_TARGET").is_none() => {
+            make_cmd.env("MACOSX_DEPLOYMENT_TARGET", "11.0");
+        }
+        _ if target.contains("linux") => {
+            make_cmd.env("TARGET_SYS", "Linux");
+        }
+        _ => {}
+    }
+    let compiler_path =
+        which::which(compiler_path).unwrap_or_else(|_| panic!("cannot find {compiler_path}"));
+    let compiler_path = compiler_path.to_str().unwrap();
+    let compiler_args = compiler.cflags_env();
+    let compiler_args = compiler_args.to_str().unwrap();
+    if env::var_os("STATIC_CC").is_none() {
+        make_cmd.env("STATIC_CC", format!("{compiler_path} {compiler_args}"));
+    }
+    if env::var_os("TARGET_LD").is_none() {
+        make_cmd.env("TARGET_LD", format!("{compiler_path} {compiler_args}"));
+    }
+    let mut xcflags = vec!["-fPIC"];
+    if lua_version == &LuaVersion::LuaJIT52 {
+        xcflags.push("-DLUAJIT_ENABLE_LUA52COMPAT");
+    }
+    if cfg!(debug_assertions) {
+        xcflags.push("-DLUA_USE_ASSERT");
+        xcflags.push("-DLUA_USE_APICHECK");
+    }
+    make_cmd.env("BUILDMODE", "static");
+    make_cmd.env("XCFLAGS", xcflags.join(" "));
+
+    match make_cmd.output().await {
+        Ok(output) if output.status.success() => utils::log_command_output(&output, config),
+        Ok(output) => {
+            return Err(BuildLuaError::CommandFailure {
+                name: "build".into(),
+                status: output.status,
+                stdout: String::from_utf8_lossy(&output.stdout).into(),
+                stderr: String::from_utf8_lossy(&output.stderr).into(),
+            });
+        }
+        Err(err) => return Err(BuildLuaError::Io(err)),
+    };
+
+    progress.map(|p| p.set_message(format!("💻 Installing Luajit {LUAJIT_MM_VERSION}")));
+
+    match Command::new(config.make_cmd())
+        .current_dir(build_dir)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .arg("install")
+        .arg(format!("PREFIX={}", install_dir.display()))
+        .output()
+        .await
+    {
+        Ok(output) if output.status.success() => utils::log_command_output(&output, config),
+        Ok(output) => {
+            return Err(BuildLuaError::CommandFailure {
+                name: "install".into(),
+                status: output.status,
+                stdout: String::from_utf8_lossy(&output.stdout).into(),
+                stderr: String::from_utf8_lossy(&output.stderr).into(),
+            });
+        }
+        Err(err) => return Err(BuildLuaError::Io(err)),
+    };
+    move_luajit_includes(install_dir).await?;
+    Ok(())
+}
+
+/// luajit installs the includes to a subdirectory.
+/// For consistency, we want them in the `include` directory
+async fn move_luajit_includes(install_dir: &Path) -> io::Result<()> {
+    let include_dir = install_dir.join("include");
+    let include_subdir = include_dir.join(format!("luajit-{LUAJIT_MM_VERSION}"));
+    if !include_subdir.is_dir() {
+        return Ok(());
+    }
+    let mut dir = fs::read_dir(&include_subdir).await?;
+    while let Some(entry) = dir.next_entry().await? {
+        let file_name = entry.file_name();
+        let src_path = entry.path();
+        let dest_path = include_dir.join(&file_name);
+        fs::copy(&src_path, &dest_path).await?;
+    }
+    fs::remove_dir_all(&include_subdir).await?;
+    Ok(())
+}
+
+async fn do_build_luajit_msvc(args: BuildLua<'_>, build_dir: &Path) -> Result<(), BuildLuaError> {
+    let lua_version = args.lua_version;
+    let config = args.config;
+    let install_dir = args.install_dir;
+    let lib_dir = install_dir.join("lib");
+    fs::create_dir_all(&lib_dir).await?;
+    let include_dir = install_dir.join("include");
+    fs::create_dir_all(&include_dir).await?;
+    let bin_dir = install_dir.join("bin");
+    fs::create_dir_all(&bin_dir).await?;
+
+    let progress = args.progress;
+
+    progress.map(|p| p.set_message(format!("🛠️ Building Luajit {LUAJIT_MM_VERSION}")));
+
+    let src_dir = build_dir.join("src");
+    let mut msvcbuild = Command::new(src_dir.join("msvcbuild.bat"));
+    msvcbuild.current_dir(&src_dir);
+    if lua_version == &LuaVersion::LuaJIT52 {
+        msvcbuild.arg("lua52compat");
+    }
+    msvcbuild.arg("static");
+    let host = Triple::host();
+    let target = host.to_string();
+    let cl = cc::windows_registry::find_tool(&target, "cl.exe").ok_or(BuildLuaError::ClNotFound)?;
+    for (k, v) in cl.env() {
+        msvcbuild.env(k, v);
+    }
+    fs::create_dir_all(&install_dir).await?;
+    match msvcbuild.output().await {
+        Ok(output) if output.status.success() => utils::log_command_output(&output, config),
+        Ok(output) => {
+            return Err(BuildLuaError::CommandFailure {
+                name: "build".into(),
+                status: output.status,
+                stdout: String::from_utf8_lossy(&output.stdout).into(),
+                stderr: String::from_utf8_lossy(&output.stderr).into(),
+            });
+        }
+        Err(err) => return Err(BuildLuaError::Io(err)),
+    };
+
+    progress.map(|p| p.set_message(format!("💻 Installing Luajit {LUAJIT_MM_VERSION}")));
+    copy_includes(&src_dir, &include_dir).await?;
+    fs::copy(src_dir.join("lua51.lib"), lib_dir.join("luajit.lib")).await?;
+    fs::copy(src_dir.join("luajit.exe"), bin_dir.join("luajit.exe")).await?;
+    Ok(())
+}
+
+async fn do_build_lua(args: BuildLua<'_>) -> Result<(), BuildLuaError> {
+    let lua_version = args.lua_version;
+    let progress = args.progress;
+
+    let build_dir = TempDir::new("lux_lua_build_dir")
+        .expect("failed to create lua_installation temp directory")
+        .into_path();
+
+    let (source_integrity, pkg_version): (Integrity, &str) = match lua_version {
+        LuaVersion::Lua51 => (LUA51_HASH.parse().unwrap(), LUA51_VERSION),
+        LuaVersion::Lua52 => (LUA52_HASH.parse().unwrap(), LUA52_VERSION),
+        LuaVersion::Lua53 => (LUA53_HASH.parse().unwrap(), LUA53_VERSION),
+        LuaVersion::Lua54 => (LUA54_HASH.parse().unwrap(), LUA54_VERSION),
+        LuaVersion::LuaJIT | LuaVersion::LuaJIT52 => unreachable!(),
+    };
+
+    let file_name = format!("lua-{pkg_version}.tar.gz");
+
+    let source_url: Url = format!("https://www.lua.org/ftp/{file_name}")
+        .parse()
+        .unwrap();
+
+    progress.map(|p| p.set_message(format!("📥 Downloading {}", &source_url)));
+
+    let response = reqwest::get(source_url)
+        .await?
+        .error_for_status()?
+        .bytes()
+        .await?;
+
+    let hash = response.hash()?;
+
+    if hash.matches(&source_integrity).is_none() {
+        return Err(BuildLuaError::SourceIntegrityMismatch {
+            expected: source_integrity,
+            actual: hash,
+        });
+    }
+
+    let cursor = Cursor::new(response);
+    let mime_type = infer::get(cursor.get_ref()).map(|file_type| file_type.mime_type());
+    operations::unpack::unpack(mime_type, cursor, true, file_name, &build_dir, progress).await?;
+
+    if cfg!(target_env = "msvc") {
+        do_build_lua_msvc(args, &build_dir, lua_version, pkg_version).await
+    } else {
+        do_build_lua_unix(args, &build_dir, lua_version, pkg_version).await
+    }
+}
+
+async fn do_build_lua_unix(
+    args: BuildLua<'_>,
+    build_dir: &Path,
+    lua_version: &LuaVersion,
+    pkg_version: &str,
+) -> Result<(), BuildLuaError> {
+    let config = args.config;
+    let progress = args.progress;
+    let install_dir = args.install_dir;
+
+    progress.map(|p| p.set_message(format!("🛠️ Building Lua {}", &pkg_version)));
+
+    let readline_spec = ExternalDependencySpec {
+        header: Some("readline/readline.h".into()),
+        library: None,
+    };
+    let build_target = match ExternalDependencyInfo::probe(
+        "readline",
+        &readline_spec,
+        &ExternalDependencySearchConfig::default(),
+    ) {
+        Ok(_) => {
+            // NOTE: The Lua < 5.4 linux targets depend on readline
+            if cfg!(target_os = "linux") {
+                if matches!(&lua_version, LuaVersion::Lua54) {
+                    "linux-readline"
+                } else {
+                    "linux"
+                }
+            } else if cfg!(target_os = "macos") {
+                "macosx"
+            } else if matches!(&lua_version, LuaVersion::Lua54) {
+                "linux"
+            } else {
+                "generic"
+            }
+        }
+        _ => "generic",
+    };
+
+    match Command::new(config.make_cmd())
+        .current_dir(build_dir)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .arg(build_target)
+        .output()
+        .await
+    {
+        Ok(output) if output.status.success() => utils::log_command_output(&output, config),
+        Ok(output) => {
+            return Err(BuildLuaError::CommandFailure {
+                name: "build".into(),
+                status: output.status,
+                stdout: String::from_utf8_lossy(&output.stdout).into(),
+                stderr: String::from_utf8_lossy(&output.stderr).into(),
+            });
+        }
+        Err(err) => return Err(BuildLuaError::Io(err)),
+    };
+
+    progress.map(|p| p.set_message(format!("💻 Installing Lua {}", &pkg_version)));
+
+    match Command::new(config.make_cmd())
+        .current_dir(build_dir)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .arg("install")
+        .arg(format!("INSTALL_TOP={}", install_dir.display()))
+        .output()
+        .await
+    {
+        Ok(output) if output.status.success() => utils::log_command_output(&output, config),
+        Ok(output) => {
+            return Err(BuildLuaError::CommandFailure {
+                name: "install".into(),
+                status: output.status,
+                stdout: String::from_utf8_lossy(&output.stdout).into(),
+                stderr: String::from_utf8_lossy(&output.stderr).into(),
+            });
+        }
+        Err(err) => return Err(BuildLuaError::Io(err)),
+    };
+
+    Ok(())
+}
+
+async fn do_build_lua_msvc(
+    args: BuildLua<'_>,
+    build_dir: &Path,
+    lua_version: &LuaVersion,
+    pkg_version: &str,
+) -> Result<(), BuildLuaError> {
+    let config = args.config;
+    let progress = args.progress;
+    let install_dir = args.install_dir;
+
+    progress.map(|p| p.set_message(format!("🛠️ Building Lua {}", &pkg_version)));
+
+    let lib_dir = install_dir.join("lib");
+    fs::create_dir_all(&lib_dir).await?;
+    let include_dir = install_dir.join("include");
+    fs::create_dir_all(&include_dir).await?;
+    let bin_dir = install_dir.join("bin");
+    fs::create_dir_all(&bin_dir).await?;
+
+    let src_dir = build_dir.join("src");
+
+    let lib_name = match lua_version {
+        LuaVersion::Lua51 => "lua5.1",
+        LuaVersion::Lua52 => "lua5.2",
+        LuaVersion::Lua53 => "lua5.3",
+        LuaVersion::Lua54 => "lua5.4",
+        LuaVersion::LuaJIT | LuaVersion::LuaJIT52 => unreachable!(),
+    };
+    let host = Triple::host();
+    let mut cc = cc::Build::new();
+    cc.cargo_output(false)
+        .cargo_metadata(false)
+        .cargo_warnings(false)
+        .warnings(config.verbose())
+        .opt_level(3)
+        .host(std::env::consts::OS)
+        .target(&host.to_string());
+
+    cc.define("LUA_USE_WINDOWS", None);
+
+    let mut lib_c_files = Vec::new();
+    let mut read_dir = fs::read_dir(&src_dir).await?;
+    while let Some(entry) = read_dir.next_entry().await? {
+        let path = entry.path();
+        if path.extension().is_some_and(|ext| ext == "c")
+            && path
+                .with_extension("")
+                .file_name()
+                .is_some_and(|name| name != "lua" && name != "luac")
+        {
+            lib_c_files.push(path);
+        }
+    }
+    cc.include(&src_dir)
+        .files(lib_c_files)
+        .out_dir(&lib_dir)
+        .try_compile(lib_name)?;
+
+    let bin_objects = cc
+        .include(&src_dir)
+        .file(src_dir.join("lua.c"))
+        .file(src_dir.join("luac.c"))
+        .out_dir(&src_dir)
+        .try_compile_intermediates()?;
+
+    progress.map(|p| p.set_message(format!("💻 Installing Lua {}", &pkg_version)));
+
+    let target = host.to_string();
+    let link =
+        cc::windows_registry::find_tool(&target, "link.exe").ok_or(BuildLuaError::LinkNotFound)?;
+
+    for name in ["lua", "luac"] {
+        let bin = bin_dir.join(format!("{name}.exe"));
+        let objects = bin_objects.iter().filter(|file| {
+            file.with_extension("").file_name().is_some_and(|fname| {
+                fname
+                    .to_string_lossy()
+                    .to_string()
+                    .ends_with(&format!("-{name}"))
+            })
+        });
+        match Command::new(link.path())
+            .arg(format!("/OUT:{}", bin.display()))
+            .args(objects)
+            .arg(format!("{}.lib", lib_dir.join(lib_name).display()))
+            .output()
+            .await
+        {
+            Ok(output) if output.status.success() => utils::log_command_output(&output, config),
+            Ok(output) => {
+                return Err(BuildLuaError::CommandFailure {
+                    name: format!("install {name}.exe"),
+                    status: output.status,
+                    stdout: String::from_utf8_lossy(&output.stdout).into(),
+                    stderr: String::from_utf8_lossy(&output.stderr).into(),
+                });
+            }
+            Err(err) => return Err(BuildLuaError::Io(err)),
+        };
+    }
+
+    copy_includes(&src_dir, &include_dir).await?;
+
+    Ok(())
+}
+
+async fn copy_includes(src_dir: &Path, include_dir: &Path) -> Result<(), io::Error> {
+    for f in &[
+        "lauxlib.h",
+        "lua.h",
+        "luaconf.h",
+        "luajit.h",
+        "lualib.h",
+        "lua.hpp",
+    ] {
+        let src_file = src_dir.join(f);
+        if src_file.is_file() {
+            fs::copy(src_file, include_dir.join(f)).await?;
+        }
+    }
+    Ok(())
+}

--- a/lux-lib/src/operations/build_project.rs
+++ b/lux-lib/src/operations/build_project.rs
@@ -164,16 +164,15 @@ impl<State: build_project_builder::State + build_project_builder::IsComplete>
         }
 
         if !args.only_deps {
-            let package = Build::new(
-                &project_toml,
-                &project_tree,
-                tree::EntryType::Entrypoint,
-                config,
-                &progress.map(|p| p.new_bar()),
-            )
-            .behaviour(BuildBehaviour::Force)
-            .build()
-            .await?;
+            let package = Build::new()
+                .rockspec(&project_toml)
+                .tree(&project_tree)
+                .entry_type(tree::EntryType::Entrypoint)
+                .config(config)
+                .progress(&progress.map(|p| p.new_bar()))
+                .behaviour(BuildBehaviour::Force)
+                .build()
+                .await?;
 
             let lockfile = project_tree.lockfile()?;
             let dependencies = lockfile

--- a/lux-lib/src/operations/install/mod.rs
+++ b/lux-lib/src/operations/install/mod.rs
@@ -204,18 +204,17 @@ async fn install_impl(
         // so that each transitive build dependency is available for the
         // next build dependencies that may depend on it.
         let mut build_lockfile = build_tree.lockfile()?.write_guard();
-        let pkg = Build::new(
-            rockspec,
-            &build_tree,
-            tree::EntryType::Entrypoint,
-            config,
-            &bar,
-        )
-        .constraint(build_dep_spec.spec.constraint())
-        .behaviour(build_dep_spec.build_behaviour)
-        .build()
-        .await
-        .map_err(|err| InstallError::BuildDependencyError(package, err))?;
+        let pkg = Build::new()
+            .rockspec(rockspec)
+            .tree(&build_tree)
+            .entry_type(tree::EntryType::Entrypoint)
+            .config(config)
+            .progress(&bar)
+            .constraint(build_dep_spec.spec.constraint())
+            .behaviour(build_dep_spec.build_behaviour)
+            .build()
+            .await
+            .map_err(|err| InstallError::BuildDependencyError(package, err))?;
         build_lockfile.add_entrypoint(&pkg);
     }
 
@@ -371,7 +370,12 @@ async fn install_rockspec(
         None => RemotePackageSourceSpec::RockSpec(rockspec_download.source_url),
     };
 
-    let pkg = Build::new(&rockspec, tree, entry_type, config, &bar)
+    let pkg = Build::new()
+        .rockspec(&rockspec)
+        .tree(tree)
+        .entry_type(entry_type)
+        .config(config)
+        .progress(&bar)
         .pin(pin)
         .opt(opt)
         .constraint(constraint)

--- a/lux-lib/src/operations/mod.rs
+++ b/lux-lib/src/operations/mod.rs
@@ -1,5 +1,6 @@
 #![allow(ambiguous_glob_reexports)]
 
+mod build_lua;
 mod build_project;
 mod download;
 mod exec;
@@ -17,6 +18,7 @@ mod test;
 mod unpack;
 mod update;
 
+pub use build_lua::*;
 pub use build_project::*;
 pub use download::*;
 pub use exec::*;

--- a/lux-lib/src/project/project_toml.rs
+++ b/lux-lib/src/project/project_toml.rs
@@ -453,7 +453,21 @@ impl PartialProjectToml {
 // but we also add a special implementation for `ProjectToml` (as providing a lua version
 // is required even by the non-validated struct).
 impl LuaVersionCompatibility for PartialProjectToml {
-    fn validate_lua_version(&self, config: &Config) -> Result<(), LuaVersionError> {
+    fn validate_lua_version(&self, version: &LuaVersion) -> Result<(), LuaVersionError> {
+        if self.supports_lua_version(version) {
+            Ok(())
+        } else {
+            Err(LuaVersionError::LuaVersionUnsupported(
+                version.clone(),
+                self.package().to_owned(),
+                self.version_template
+                    .try_generate(&self.project_root)
+                    .unwrap_or(PackageVersion::default_dev_version()),
+            ))
+        }
+    }
+
+    fn validate_lua_version_from_config(&self, config: &Config) -> Result<(), LuaVersionError> {
         let _ = self.lua_version_matches(config)?;
         Ok(())
     }

--- a/lux-lib/src/rockspec/mod.rs
+++ b/lux-lib/src/rockspec/mod.rs
@@ -63,9 +63,13 @@ pub trait Rockspec {
 }
 
 pub trait LuaVersionCompatibility {
+    /// Ensures that the rockspec is compatible with the specified lua version.
+    /// Returns an error if the rockspec is not compatible.
+    fn validate_lua_version(&self, lua_version: &LuaVersion) -> Result<(), LuaVersionError>;
+
     /// Ensures that the rockspec is compatible with the lua version established in the config.
     /// Returns an error if the rockspec is not compatible.
-    fn validate_lua_version(&self, config: &Config) -> Result<(), LuaVersionError>;
+    fn validate_lua_version_from_config(&self, config: &Config) -> Result<(), LuaVersionError>;
 
     /// Ensures that the rockspec is compatible with the lua version established in the config,
     /// and returns the lua version from the config if it is compatible.
@@ -79,7 +83,19 @@ pub trait LuaVersionCompatibility {
 }
 
 impl<T: Rockspec> LuaVersionCompatibility for T {
-    fn validate_lua_version(&self, config: &Config) -> Result<(), LuaVersionError> {
+    fn validate_lua_version(&self, version: &LuaVersion) -> Result<(), LuaVersionError> {
+        if self.supports_lua_version(version) {
+            Ok(())
+        } else {
+            Err(LuaVersionError::LuaVersionUnsupported(
+                version.clone(),
+                self.package().to_owned(),
+                self.version().to_owned(),
+            ))
+        }
+    }
+
+    fn validate_lua_version_from_config(&self, config: &Config) -> Result<(), LuaVersionError> {
         let _ = self.lua_version_matches(config)?;
         Ok(())
     }

--- a/lux-lib/tests/build.rs
+++ b/lux-lib/tests/build.rs
@@ -5,9 +5,9 @@ use assert_fs::TempDir;
 use lux_lib::{
     build::{Build, BuildBehaviour::Force},
     config::{ConfigBuilder, LuaVersion},
-    lua_installation::detect_installed_lua_version,
+    lua_installation::{detect_installed_lua_version, LuaInstallation},
     lua_rockspec::RemoteLuaRockspec,
-    progress::{MultiProgress, Progress},
+    progress::Progress,
     project::Project,
     tree,
 };
@@ -34,19 +34,21 @@ async fn builtin_build() {
         .build()
         .unwrap();
 
-    let progress = MultiProgress::new();
-    let bar = progress.new_bar();
+    let bar = Progress::NoProgress;
 
-    let tree = config
-        .user_tree(LuaVersion::from(&config).unwrap().clone())
+    let lua = LuaInstallation::new_from_config(&config, &bar)
+        .await
         .unwrap();
+
+    let tree = config.user_tree(lua.version.clone()).unwrap();
 
     Build::new()
         .rockspec(&rockspec)
+        .lua(&lua)
         .tree(&tree)
         .entry_type(tree::EntryType::Entrypoint)
         .config(&config)
-        .progress(&Progress::Progress(bar))
+        .progress(&bar)
         .behaviour(Force)
         .build()
         .await
@@ -72,19 +74,21 @@ async fn make_build() {
         .build()
         .unwrap();
 
-    let progress = MultiProgress::new();
-    let bar = progress.new_bar();
+    let bar = Progress::NoProgress;
 
-    let tree = config
-        .user_tree(LuaVersion::from(&config).unwrap().clone())
+    let lua = LuaInstallation::new_from_config(&config, &bar)
+        .await
         .unwrap();
+
+    let tree = config.user_tree(lua.version.clone()).unwrap();
 
     Build::new()
         .rockspec(&rockspec)
+        .lua(&lua)
         .tree(&tree)
         .entry_type(tree::EntryType::Entrypoint)
         .config(&config)
-        .progress(&Progress::Progress(bar))
+        .progress(&bar)
         .behaviour(Force)
         .build()
         .await
@@ -124,19 +128,21 @@ async fn test_build_rockspec(rockspec_path: PathBuf) {
         .build()
         .unwrap();
 
-    let progress = MultiProgress::new();
-    let bar = progress.new_bar();
+    let bar = Progress::NoProgress;
 
-    let tree = config
-        .user_tree(LuaVersion::from(&config).unwrap().clone())
+    let lua = LuaInstallation::new_from_config(&config, &bar)
+        .await
         .unwrap();
+
+    let tree = config.user_tree(lua.version.clone()).unwrap();
 
     Build::new()
         .rockspec(&rockspec)
+        .lua(&lua)
         .tree(&tree)
         .entry_type(tree::EntryType::Entrypoint)
         .config(&config)
-        .progress(&Progress::Progress(bar))
+        .progress(&bar)
         .behaviour(Force)
         .build()
         .await
@@ -167,8 +173,11 @@ async fn treesitter_parser_build() {
         .build()
         .unwrap();
 
-    let progress = MultiProgress::new();
-    let bar = progress.new_bar();
+    let bar = Progress::NoProgress;
+
+    let lua = LuaInstallation::new_from_config(&config, &bar)
+        .await
+        .unwrap();
 
     let tree = config
         .user_tree(LuaVersion::from(&config).unwrap().clone())
@@ -176,10 +185,11 @@ async fn treesitter_parser_build() {
 
     Build::new()
         .rockspec(&rockspec)
+        .lua(&lua)
         .tree(&tree)
         .entry_type(tree::EntryType::Entrypoint)
         .config(&config)
-        .progress(&Progress::Progress(bar))
+        .progress(&bar)
         .behaviour(Force)
         .build()
         .await
@@ -204,15 +214,19 @@ async fn test_build_local_project_no_source() {
         .unwrap();
 
     let tree = project.tree(&config).unwrap();
-    let progress = MultiProgress::new();
-    let bar = progress.new_bar();
+    let bar = Progress::NoProgress;
+
+    let lua = LuaInstallation::new_from_config(&config, &bar)
+        .await
+        .unwrap();
 
     let package = Build::new()
         .rockspec(&project_toml)
+        .lua(&lua)
         .tree(&tree)
         .entry_type(tree::EntryType::Entrypoint)
         .config(&config)
-        .progress(&Progress::Progress(bar))
+        .progress(&bar)
         .behaviour(Force)
         .build()
         .await
@@ -244,15 +258,19 @@ async fn test_build_local_project_only_src() {
         .unwrap();
 
     let tree = project.tree(&config).unwrap();
-    let progress = MultiProgress::new();
-    let bar = progress.new_bar();
+    let bar = Progress::NoProgress;
+
+    let lua = LuaInstallation::new_from_config(&config, &bar)
+        .await
+        .unwrap();
 
     let pkg = Build::new()
         .rockspec(&project_toml)
+        .lua(&lua)
         .tree(&tree)
         .entry_type(tree::EntryType::Entrypoint)
         .config(&config)
-        .progress(&Progress::Progress(bar))
+        .progress(&bar)
         .behaviour(Force)
         .build()
         .await
@@ -301,12 +319,18 @@ fn test_build_multiple_treesitter_parsers() {
         let rockspec = rockspec.clone();
 
         handles.push(runtime.spawn(async move {
+            let bar = Progress::NoProgress;
+            let lua = LuaInstallation::new_from_config(&config, &bar)
+                .await
+                .unwrap();
+
             Build::new()
                 .rockspec(&rockspec)
+                .lua(&lua)
                 .tree(&tree)
                 .entry_type(tree::EntryType::Entrypoint)
                 .config(&config)
-                .progress(&Progress::NoProgress)
+                .progress(&bar)
                 .behaviour(Force)
                 .build()
                 .await
@@ -335,15 +359,19 @@ async fn build_project_with_git_dependency() {
         .unwrap();
 
     let tree = project.tree(&config).unwrap();
-    let progress = MultiProgress::new();
-    let bar = progress.new_bar();
+    let bar = Progress::NoProgress;
+
+    let lua = LuaInstallation::new_from_config(&config, &bar)
+        .await
+        .unwrap();
 
     Build::new()
         .rockspec(&project_toml)
+        .lua(&lua)
         .tree(&tree)
         .entry_type(tree::EntryType::Entrypoint)
         .config(&config)
-        .progress(&Progress::Progress(bar))
+        .progress(&bar)
         .behaviour(Force)
         .build()
         .await
@@ -368,15 +396,19 @@ async fn test_multiline_command_build() {
         .unwrap();
 
     let tree = project.tree(&config).unwrap();
-    let progress = MultiProgress::new();
-    let bar = progress.new_bar();
+    let bar = Progress::NoProgress;
+
+    let lua = LuaInstallation::new_from_config(&config, &bar)
+        .await
+        .unwrap();
 
     let package = Build::new()
         .rockspec(&project_toml)
+        .lua(&lua)
         .tree(&tree)
         .entry_type(tree::EntryType::Entrypoint)
         .config(&config)
-        .progress(&Progress::Progress(bar))
+        .progress(&bar)
         .behaviour(BuildBehaviour::Force)
         .build()
         .await

--- a/lux-lib/tests/build.rs
+++ b/lux-lib/tests/build.rs
@@ -41,17 +41,16 @@ async fn builtin_build() {
         .user_tree(LuaVersion::from(&config).unwrap().clone())
         .unwrap();
 
-    Build::new(
-        &rockspec,
-        &tree,
-        tree::EntryType::Entrypoint,
-        &config,
-        &Progress::Progress(bar),
-    )
-    .behaviour(Force)
-    .build()
-    .await
-    .unwrap();
+    Build::new()
+        .rockspec(&rockspec)
+        .tree(&tree)
+        .entry_type(tree::EntryType::Entrypoint)
+        .config(&config)
+        .progress(&Progress::Progress(bar))
+        .behaviour(Force)
+        .build()
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
@@ -80,17 +79,16 @@ async fn make_build() {
         .user_tree(LuaVersion::from(&config).unwrap().clone())
         .unwrap();
 
-    Build::new(
-        &rockspec,
-        &tree,
-        tree::EntryType::Entrypoint,
-        &config,
-        &Progress::Progress(bar),
-    )
-    .behaviour(Force)
-    .build()
-    .await
-    .unwrap();
+    Build::new()
+        .rockspec(&rockspec)
+        .tree(&tree)
+        .entry_type(tree::EntryType::Entrypoint)
+        .config(&config)
+        .progress(&Progress::Progress(bar))
+        .behaviour(Force)
+        .build()
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
@@ -133,17 +131,16 @@ async fn test_build_rockspec(rockspec_path: PathBuf) {
         .user_tree(LuaVersion::from(&config).unwrap().clone())
         .unwrap();
 
-    Build::new(
-        &rockspec,
-        &tree,
-        tree::EntryType::Entrypoint,
-        &config,
-        &Progress::Progress(bar),
-    )
-    .behaviour(Force)
-    .build()
-    .await
-    .unwrap();
+    Build::new()
+        .rockspec(&rockspec)
+        .tree(&tree)
+        .entry_type(tree::EntryType::Entrypoint)
+        .config(&config)
+        .progress(&Progress::Progress(bar))
+        .behaviour(Force)
+        .build()
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
@@ -177,17 +174,16 @@ async fn treesitter_parser_build() {
         .user_tree(LuaVersion::from(&config).unwrap().clone())
         .unwrap();
 
-    Build::new(
-        &rockspec,
-        &tree,
-        tree::EntryType::Entrypoint,
-        &config,
-        &Progress::Progress(bar),
-    )
-    .behaviour(Force)
-    .build()
-    .await
-    .unwrap();
+    Build::new()
+        .rockspec(&rockspec)
+        .tree(&tree)
+        .entry_type(tree::EntryType::Entrypoint)
+        .config(&config)
+        .progress(&Progress::Progress(bar))
+        .behaviour(Force)
+        .build()
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
@@ -211,17 +207,16 @@ async fn test_build_local_project_no_source() {
     let progress = MultiProgress::new();
     let bar = progress.new_bar();
 
-    let package = Build::new(
-        &project_toml,
-        &tree,
-        tree::EntryType::Entrypoint,
-        &config,
-        &Progress::Progress(bar),
-    )
-    .behaviour(Force)
-    .build()
-    .await
-    .unwrap();
+    let package = Build::new()
+        .rockspec(&project_toml)
+        .tree(&tree)
+        .entry_type(tree::EntryType::Entrypoint)
+        .config(&config)
+        .progress(&Progress::Progress(bar))
+        .behaviour(Force)
+        .build()
+        .await
+        .unwrap();
 
     let rock_layout = tree.installed_rock_layout(&package).unwrap();
     let conf_file = rock_layout.conf.join("foo").join("bar.toml");
@@ -252,17 +247,16 @@ async fn test_build_local_project_only_src() {
     let progress = MultiProgress::new();
     let bar = progress.new_bar();
 
-    let pkg = Build::new(
-        &project_toml,
-        &tree,
-        tree::EntryType::Entrypoint,
-        &config,
-        &Progress::Progress(bar),
-    )
-    .behaviour(Force)
-    .build()
-    .await
-    .unwrap();
+    let pkg = Build::new()
+        .rockspec(&project_toml)
+        .tree(&tree)
+        .entry_type(tree::EntryType::Entrypoint)
+        .config(&config)
+        .progress(&Progress::Progress(bar))
+        .behaviour(Force)
+        .build()
+        .await
+        .unwrap();
 
     let layout = tree.installed_rock_layout(&pkg).unwrap();
     assert!(layout.src.is_dir());
@@ -307,17 +301,16 @@ fn test_build_multiple_treesitter_parsers() {
         let rockspec = rockspec.clone();
 
         handles.push(runtime.spawn(async move {
-            Build::new(
-                &rockspec,
-                &tree,
-                tree::EntryType::Entrypoint,
-                &config,
-                &Progress::NoProgress,
-            )
-            .behaviour(Force)
-            .build()
-            .await
-            .unwrap()
+            Build::new()
+                .rockspec(&rockspec)
+                .tree(&tree)
+                .entry_type(tree::EntryType::Entrypoint)
+                .config(&config)
+                .progress(&Progress::NoProgress)
+                .behaviour(Force)
+                .build()
+                .await
+                .unwrap()
         }));
     }
 
@@ -345,17 +338,16 @@ async fn build_project_with_git_dependency() {
     let progress = MultiProgress::new();
     let bar = progress.new_bar();
 
-    Build::new(
-        &project_toml,
-        &tree,
-        tree::EntryType::Entrypoint,
-        &config,
-        &Progress::Progress(bar),
-    )
-    .behaviour(Force)
-    .build()
-    .await
-    .unwrap();
+    Build::new()
+        .rockspec(&project_toml)
+        .tree(&tree)
+        .entry_type(tree::EntryType::Entrypoint)
+        .config(&config)
+        .progress(&Progress::Progress(bar))
+        .behaviour(Force)
+        .build()
+        .await
+        .unwrap();
 }
 
 #[cfg(not(target_env = "msvc"))]
@@ -379,17 +371,16 @@ async fn test_multiline_command_build() {
     let progress = MultiProgress::new();
     let bar = progress.new_bar();
 
-    let package = Build::new(
-        &project_toml,
-        &tree,
-        tree::EntryType::Entrypoint,
-        &config,
-        &Progress::Progress(bar),
-    )
-    .behaviour(BuildBehaviour::Force)
-    .build()
-    .await
-    .unwrap();
+    let package = Build::new()
+        .rockspec(&project_toml)
+        .tree(&tree)
+        .entry_type(tree::EntryType::Entrypoint)
+        .config(&config)
+        .progress(&Progress::Progress(bar))
+        .behaviour(BuildBehaviour::Force)
+        .build()
+        .await
+        .unwrap();
 
     let rock_layout = tree.installed_rock_layout(&package).unwrap();
     let success_dir = rock_layout.src.join("success");

--- a/lux-lib/tests/build_lua.rs
+++ b/lux-lib/tests/build_lua.rs
@@ -1,0 +1,110 @@
+use assert_fs::{assert::PathAssert, prelude::PathChild};
+use lux_lib::{
+    config::{ConfigBuilder, LuaVersion},
+    operations::BuildLua,
+    progress::{MultiProgress, Progress},
+};
+use predicates::prelude::predicate;
+
+#[tokio::test]
+async fn test_build_lua() {
+    let progress = MultiProgress::new();
+    for lua_version in [
+        LuaVersion::Lua51,
+        LuaVersion::Lua52,
+        LuaVersion::Lua53,
+        LuaVersion::Lua54,
+    ] {
+        let target_dir = assert_fs::TempDir::new().unwrap();
+        let target_path = target_dir.to_path_buf();
+        let user_tree = assert_fs::TempDir::new().unwrap();
+        let config = ConfigBuilder::new()
+            .unwrap()
+            .user_tree(Some(user_tree.to_path_buf()))
+            .lua_version(Some(lua_version.clone()))
+            .build()
+            .unwrap();
+        let bar = Progress::Progress(progress.new_bar());
+        BuildLua::new()
+            .lua_version(&lua_version)
+            .progress(&bar)
+            .install_dir(&target_path)
+            .config(&config)
+            .build()
+            .await
+            .unwrap();
+        let lua_bin_dir = target_dir.child("bin");
+        lua_bin_dir.assert(predicate::path::is_dir());
+        let lua_bin = if cfg!(target_env = "msvc") {
+            lua_bin_dir.child("lua.exe")
+        } else {
+            lua_bin_dir.child("lua")
+        };
+        lua_bin.assert(predicate::path::is_file());
+        let lua_include_dir = target_dir.child("include");
+        lua_include_dir.assert(predicate::path::is_dir());
+        let lua_header = lua_include_dir.child("lua.h");
+        lua_header.assert(predicate::path::is_file());
+        let lua_lib_dir = target_dir.child("lib");
+        lua_lib_dir.assert(predicate::path::is_dir());
+        let lua_lib = if cfg!(target_env = "msvc") {
+            let lib_name = match lua_version {
+                LuaVersion::Lua51 => "lua5.1.lib",
+                LuaVersion::Lua52 => "lua5.2.lib",
+                LuaVersion::Lua53 => "lua5.3.lib",
+                LuaVersion::Lua54 => "lua5.4.lib",
+                LuaVersion::LuaJIT | LuaVersion::LuaJIT52 => unreachable!(),
+            };
+            lua_lib_dir.child(lib_name)
+        } else {
+            lua_lib_dir.child("liblua.a")
+        };
+        lua_lib.assert(predicate::path::is_file());
+    }
+}
+
+#[tokio::test]
+async fn test_build_luajit() {
+    let progress = MultiProgress::new();
+    for lua_version in [LuaVersion::LuaJIT, LuaVersion::LuaJIT52] {
+        let target_dir = assert_fs::TempDir::new().unwrap();
+        let target_path = target_dir.to_path_buf();
+        let user_tree = assert_fs::TempDir::new().unwrap();
+        let config = ConfigBuilder::new()
+            .unwrap()
+            .user_tree(Some(user_tree.to_path_buf()))
+            .lua_version(Some(lua_version.clone()))
+            .build()
+            .unwrap();
+        let bar = Progress::Progress(progress.new_bar());
+        BuildLua::new()
+            .lua_version(&lua_version)
+            .progress(&bar)
+            .install_dir(&target_path)
+            .config(&config)
+            .build()
+            .await
+            .unwrap();
+        let luajit_bin_dir = target_dir.child("bin");
+        luajit_bin_dir.assert(predicate::path::is_dir());
+        let luajit_bin = if cfg!(target_env = "msvc") {
+            luajit_bin_dir.child("luajit.exe")
+        } else {
+            luajit_bin_dir.child("luajit")
+        };
+        luajit_bin.assert(predicate::path::exists()); // May be a symlink
+        let luajit_include_dir = target_dir.child("include");
+        luajit_include_dir.assert(predicate::path::is_dir());
+        let lua_header = luajit_include_dir.child("lua.h");
+        lua_header.assert(predicate::path::is_file());
+        let luajit_lib_dir = target_dir.child("lib");
+        luajit_lib_dir.assert(predicate::path::is_dir());
+        let luajit_lib = if cfg!(target_env = "msvc") {
+            luajit_lib_dir.child("luajit.lib")
+        } else {
+            // NOTE: luajit builds a libluajit-5.1 lib even if 5.2 compatibility is enabled.
+            luajit_lib_dir.child("libluajit-5.1.a")
+        };
+        luajit_lib.assert(predicate::path::is_file());
+    }
+}

--- a/lux-lib/tests/luarocks_installation.rs
+++ b/lux-lib/tests/luarocks_installation.rs
@@ -28,7 +28,11 @@ async fn luarocks_make() {
     let luarocks = LuaRocksInstallation::new(&config, tree).unwrap();
     let progress = Progress::Progress(MultiProgress::new());
     let bar = progress.map(|p| p.add(ProgressBar::from("Installing luarocks".to_string())));
-    luarocks.ensure_installed(&bar).await.unwrap();
+    let lua =
+        LuaInstallation::new_from_config(&config, &progress.map(|progress| progress.new_bar()))
+            .await
+            .unwrap();
+    luarocks.ensure_installed(&lua, &bar).await.unwrap();
     let project_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("resources/test/sample-projects/no-build-spec/");
     let rockspec_path = project_root.join("foo-1.0.0-1.rockspec");

--- a/lux-lib/tests/luarocks_installation.rs
+++ b/lux-lib/tests/luarocks_installation.rs
@@ -36,7 +36,11 @@ async fn luarocks_make() {
     build_dir.copy_from(&project_root, &["**"]).unwrap();
     let dest_dir = TempDir::new().unwrap();
     let lua_version = LuaVersion::from(&config).unwrap_or(&LuaVersion::Lua51);
-    let lua = LuaInstallation::new(lua_version, &config).await.unwrap();
+    let progress = MultiProgress::new();
+    let bar = Progress::Progress(progress.new_bar());
+    let lua = LuaInstallation::new(lua_version, &config, &bar)
+        .await
+        .unwrap();
     luarocks
         .make(&rockspec_path, build_dir.path(), dest_dir.path(), &lua)
         .await

--- a/lux-workspace-hack/Cargo.toml
+++ b/lux-workspace-hack/Cargo.toml
@@ -22,6 +22,7 @@ bstr = { version = "1" }
 clap = { version = "4", features = ["derive", "env"] }
 clap_builder = { version = "4", default-features = false, features = ["color", "env", "help", "std", "suggestions", "usage"] }
 crossbeam-utils = { version = "0.8" }
+either = { version = "1" }
 futures-channel = { version = "0.3", features = ["sink"] }
 futures-core = { version = "0.3" }
 futures-sink = { version = "0.3" }

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -173,13 +173,19 @@ in {
       inherit (luxCargo) version;
       src = self;
 
-      buildInputs = commonArgs.buildInputs ++ [final.lua5_4];
+      buildInputs =
+        commonArgs.buildInputs
+        ++ [
+          # make sure this is the same as the nativeCheckInputs lua
+          final.lua5_4
+        ];
 
       nativeCheckInputs = with final; [
+        # make sure this is the same as the buildInputs lua, otherwise pkg-config won't find it
+        lua5_4
         cacert
         cargo-nextest
         zlib # used for checking external dependencies
-        lua
         nix # we use nix-hash in tests
       ];
 


### PR DESCRIPTION
Fixes #789.

The `lua-src` and `luajit-src` crates are meant to be used at build time, not runtime.
When using a pre-built lux binary, the respective Lua source directories of these crates don't exist.
So instead of relying on those crates to build Lua, Lux should fetch the sources and then build them.

This has the added benefit that lux now builds a Lua binary, too. So users don't need to have a Lua installation to be able to run commands like `lx lua` or `lx run`. It also opens the door for the possibility of bundling Lua applications.

Note: I am not putting this in a draft state, because I need to run the tests on Windows.

Status:

- [x] Luajit on unix
- [x] Lua on unix
- [x] Luajit on msvc
- [x] Lua on msvc

For now, we hard-code the source URLs, versions and source hashes. We may want to make this configurable at a later time (yagni for now).